### PR TITLE
Implement loading ClassLoaderHandler from Java’s ServiceLoader.

### DIFF
--- a/src/main/java/io/github/classgraph/ClassLoaderHandler.java
+++ b/src/main/java/io/github/classgraph/ClassLoaderHandler.java
@@ -36,7 +36,7 @@ import io.github.classgraph.utils.LogNode;
  *
  * <p>
  * Custom ClassLoaderHandlers can be registered by listing their fully-qualified class name in the file:
- * META-INF/services/io.github.classgraph.scanner.classloaderhandler.ClassLoaderHandler
+ * META-INF/services/io.github.classgraph.ClassLoaderHandler
  *
  * <p>
  * However, if you do create a custom ClassLoaderHandler, please consider submitting a patch upstream for
@@ -45,16 +45,16 @@ import io.github.classgraph.utils.LogNode;
 public interface ClassLoaderHandler {
     /**
      * The fully-qualified names of handled classloader classes.
-     * 
+     *
      * @return The names of ClassLoaders that this ClassLoaderHandler can handle.
      */
-    public String[] handledClassLoaders();
+    String[] handledClassLoaders();
 
     /**
      * The delegation order configuration for a given ClassLoader instance (this is usually PARENT_FIRST for most
      * ClassLoaders, but this can be overridden by some ClassLoaders, e.g. WebSphere).
      */
-    public enum DelegationOrder {
+    enum DelegationOrder {
         /** Delegate to parent before handling in child. */
         PARENT_FIRST,
         /** Handle classloading in child before delegating to parent. */
@@ -64,24 +64,24 @@ public interface ClassLoaderHandler {
     /**
      * If this ClassLoader delegates directly to an embedded classloader instance, return it here, otherwise return
      * null.
-     * 
+     *
      * @param outerClassLoaderInstance
      *            The outer ClassLoader instance to check for an embedded ClassLoader.
      * @return The embedded ClassLoader to use instead of the outer ClassLoader, or null to use the outer
      *         ClassLoader.
      */
-    public ClassLoader getEmbeddedClassLoader(ClassLoader outerClassLoaderInstance);
+    ClassLoader getEmbeddedClassLoader(ClassLoader outerClassLoaderInstance);
 
     /**
      * The delegation order configuration for a given ClassLoader instance (this is usually PARENT_FIRST for most
      * ClassLoaders, since you don't generally want to be able to override system classes with user classes, but
      * this can be overridden by some ClassLoaders, e.g. WebSphere).
-     * 
+     *
      * @param classLoaderInstance
      *            The ClassLoader to get the delegation order for.
      * @return The delegation order for the given ClassLoader.
      */
-    public DelegationOrder getDelegationOrder(ClassLoader classLoaderInstance);
+    DelegationOrder getDelegationOrder(ClassLoader classLoaderInstance);
 
     /**
      * Determine if a given ClassLoader can be handled (meaning that its classpath elements can be extracted from
@@ -106,6 +106,6 @@ public interface ClassLoaderHandler {
      * @throws Exception
      *             If anything goes wrong while fetching classpath elements.
      */
-    public void handle(ScanSpec scanSpec, final ClassLoader classLoader, final ClasspathOrder classpathOrderOut,
+    void handle(ScanSpec scanSpec, final ClassLoader classLoader, final ClasspathOrder classpathOrderOut,
             LogNode log) throws Exception;
 }

--- a/src/test/java/io/github/classgraph/features/ClassLoaderHandlerSPI.java
+++ b/src/test/java/io/github/classgraph/features/ClassLoaderHandlerSPI.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of ClassGraph.
+ *
+ * Author: Michael J. Simons
+ *
+ * Hosted at: https://github.com/classgraph/classgraph
+ *
+ * --
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Luke Hutchison
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.classgraph.features;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.classgraph.ClassLoaderHandler;
+import io.github.classgraph.ScanSpec;
+import io.github.classgraph.classloaderhandler.ClassLoaderHandlerRegistry;
+import io.github.classgraph.utils.ClasspathOrder;
+import io.github.classgraph.utils.LogNode;
+
+import org.assertj.core.api.iterable.Extractor;
+import org.junit.Test;
+
+public class ClassLoaderHandlerSPI {
+    @Test
+    public void shouldLoadAdditionalClassLoaderThroughSPI() {
+        assertThat(ClassLoaderHandlerRegistry.DEFAULT_CLASS_LOADER_HANDLERS).extracting(
+            new Extractor<ClassLoaderHandlerRegistry.ClassLoaderHandlerRegistryEntry, Object>() {
+
+                @Override
+                public Object extract(ClassLoaderHandlerRegistry.ClassLoaderHandlerRegistryEntry input) {
+                    return input.classLoaderHandlerClass;
+                }
+            }
+        ).contains(AFancyClassLoaderHandler.class);
+    }
+
+    public static class AFancyClassLoaderHandler implements ClassLoaderHandler {
+
+        public AFancyClassLoaderHandler() {
+        }
+
+        @Override
+        public String[] handledClassLoaders() {
+            return new String[0];
+        }
+
+        @Override
+        public ClassLoader getEmbeddedClassLoader(ClassLoader outerClassLoaderInstance) {
+            return null;
+        }
+
+        @Override public DelegationOrder getDelegationOrder(ClassLoader classLoaderInstance) {
+            return null;
+        }
+
+        @Override
+        public void handle(ScanSpec scanSpec, ClassLoader classLoader, ClasspathOrder classpathOrderOut, LogNode log) {
+        }
+    }
+}

--- a/src/test/resources/META-INF/services/io.github.classgraph.ClassLoaderHandler
+++ b/src/test/resources/META-INF/services/io.github.classgraph.ClassLoaderHandler
@@ -1,0 +1,1 @@
+io.github.classgraph.features.ClassLoaderHandlerSPI$AFancyClassLoaderHandler


### PR DESCRIPTION
The `ClassLoaderHandler` promises in it's JavaDoc that additional handlers can be loaded through the standard Java SPI. That's not the case.

This PR add this feature and additionally fixes the doc. Please see the single commit message for more detail (quoted below).

All the standard handlers could maybe be loaded through the SPI as well, but to keep the order one would have to add one additional interface method and I understand ClassGraph should still support Java 7, so I didn't add a default interface method.

Also, thanks for your work on ClassGraph, we are using it in [Neo4j-OGM](https://github.com/neo4j/neo4j-ogm) and are currently in the process of upgrading from FastClasspathScanner code.

> This commit adds loading of additional ClassLoaderHandler from Java’s Serviceloader SPI.
> 
> The default list of handlers is now created in a static initializer block and than supplemented by a list of dynamically loaded handlers.
> To use the the handlers from the SPI, ClassLoaderHandlerRegistryEntry had to have a new constructor, taking, taking in the prepopulated handler.
> 