### PR TITLE
GH-267: Make ClassGraph work with Spring Boot DevTools / RestartClassLoader.

### DIFF
--- a/src/main/java/io/github/classgraph/ClassGraphClassLoader.java
+++ b/src/main/java/io/github/classgraph/ClassGraphClassLoader.java
@@ -45,7 +45,7 @@ class ClassGraphClassLoader extends ClassLoader {
      *            The ScanResult.
      */
     ClassGraphClassLoader(final ScanResult scanResult) {
-        super();
+        super(null);
         this.scanResult = scanResult;
         registerAsParallelCapable();
     }

--- a/src/main/java/io/github/classgraph/classloaderhandler/ClassLoaderHandlerRegistry.java
+++ b/src/main/java/io/github/classgraph/classloaderhandler/ClassLoaderHandlerRegistry.java
@@ -53,6 +53,7 @@ public class ClassLoaderHandlerRegistry {
                 new ClassLoaderHandlerRegistryEntry(WebsphereLibertyClassLoaderHandler.class),
                 new ClassLoaderHandlerRegistryEntry(WebsphereTraditionalClassLoaderHandler.class),
                 new ClassLoaderHandlerRegistryEntry(OSGiDefaultClassLoaderHandler.class),
+                new ClassLoaderHandlerRegistryEntry(SpringBootRestartClassLoaderHandler.class),
 
                 // JPMS support
                 new ClassLoaderHandlerRegistryEntry(JPMSClassLoaderHandler.class),

--- a/src/main/java/io/github/classgraph/classloaderhandler/SpringBootRestartClassLoaderHandler.java
+++ b/src/main/java/io/github/classgraph/classloaderhandler/SpringBootRestartClassLoaderHandler.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of ClassGraph.
+ *
+ * Author: Michael J. Simons
+ *
+ * Hosted at: https://github.com/classgraph/classgraph
+ *
+ * --
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Luke Hutchison
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.classgraph.classloaderhandler;
+
+import io.github.classgraph.ClassLoaderHandler;
+import io.github.classgraph.ScanSpec;
+import io.github.classgraph.utils.ClasspathOrder;
+import io.github.classgraph.utils.LogNode;
+
+/**
+ * This handler uses {@link io.github.classgraph.ClassLoaderHandler.DelegationOrder#PARENT_LAST} to support
+ * the <code>RestartClassLoader</code> of Spring Boot's devtools. <code>RestartClassLoader</code> provides
+ * parent last loading for specified URLs (those are all that are supposed to be changed during development).
+ * Therefor the handler for that class loader also has to delegate in <code>PARENT_LAST</code> order.
+ */
+class SpringBootRestartClassLoaderHandler implements ClassLoaderHandler {
+
+	// Spring Boots devtools class loader is an extension of URLClassLoader so there's no need
+	// to use reflection to access the urls supported and we can delegate the handling to an
+	// internal instance of URLClassLoaderHandler.
+	private final URLClassLoaderHandler handlerDelegate = new URLClassLoaderHandler();
+
+	@Override
+	public String[] handledClassLoaders() {
+		return new String[] { //
+			"org.springframework.boot.devtools.restart.classloader.RestartClassLoader" };
+	}
+
+	@Override
+	public ClassLoader getEmbeddedClassLoader(final ClassLoader outerClassLoaderInstance) {
+		return null;
+	}
+
+	@Override
+	public ClassLoaderHandler.DelegationOrder getDelegationOrder(final ClassLoader classLoaderInstance) {
+		return DelegationOrder.PARENT_LAST;
+	}
+
+	@Override
+	public void handle(final ScanSpec scanSpec, final ClassLoader classLoader, final ClasspathOrder classpathOrderOut, final LogNode log) {
+		handlerDelegate.handle(scanSpec, classLoader, classpathOrderOut, log);
+	}
+}

--- a/src/test/java/io/github/classgraph/issues/issue267/ClassLoadingWorksWithParentLastLoaders.java
+++ b/src/test/java/io/github/classgraph/issues/issue267/ClassLoadingWorksWithParentLastLoaders.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of ClassGraph.
+ *
+ * Author: Michael J. Simons
+ *
+ * Hosted at: https://github.com/classgraph/classgraph
+ *
+ * --
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Luke Hutchison
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.classgraph.issues.issue267;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
+
+import java.lang.reflect.Field;
+
+import com.xyz.meta.A;
+
+public class ClassLoadingWorksWithParentLastLoaders {
+	public void assertCorrectClassLoaders(final String expectedClassLoader) throws Exception {
+
+		A a = new A();
+		// Checking the precondition here: We forced our classloader onto "everything"
+		assertThat(ClassLoadingWorksWithParentLastLoaders.class.getClassLoader().getClass().getSimpleName()).isEqualTo(expectedClassLoader);
+		assertThat(a.getClass().getClassLoader().getClass().getSimpleName()).isEqualTo(expectedClassLoader);
+
+		ClassGraph classGraph = new ClassGraph()
+			.whitelistPackages("com.xyz.meta").enableAllInfo();
+
+		// ClassGraph is in that setup not part of the RestartClass loader. That one takes by default only
+		// URLs from the current project into consideration and can only be modified by adding additional
+		// directories, see https://github.com/spring-projects/spring-boot/issues/12869
+		assertThat(classGraph.getClass().getClassLoader().getClass().getSimpleName()).isEqualTo("AppClassLoader");
+
+		// Now use ClassGraph to find everything
+		try (ScanResult scanResult = classGraph.scan()) {
+			ClassInfo classInfo = scanResult.getAllClasses().filter(new ClassInfoList.ClassInfoFilter() {
+				@Override public boolean accept(ClassInfo classInfo) {
+					return "A".equals(classInfo.getSimpleName());
+				}
+			}).get(0);
+
+			// ClassGraph finds "A" through the RestartClass Loader
+			final Field classLoadersField = classInfo.getClass().getDeclaredField("classLoaders");
+			classLoadersField.setAccessible(true);
+			assertThat(((ClassLoader[]) classLoadersField.get(classInfo))[0].getClass().getSimpleName())
+				.isEqualTo(expectedClassLoader);
+
+			// And it should load it through the same class loader it found it with
+			Class<?> aClassLoadedThroughClassGraph = classInfo.loadClass();
+			assertThat(aClassLoadedThroughClassGraph.getClassLoader().getClass().getSimpleName())
+				.isEqualTo(expectedClassLoader);
+			// and thus assignable
+			assertThat(a.getClass().isAssignableFrom(aClassLoadedThroughClassGraph));
+		}
+	}
+}

--- a/src/test/java/io/github/classgraph/issues/issue267/ClassLoadingWorksWithParentLastLoadersStub.java
+++ b/src/test/java/io/github/classgraph/issues/issue267/ClassLoadingWorksWithParentLastLoadersStub.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of ClassGraph.
+ *
+ * Author: Michael J. Simons
+ *
+ * Hosted at: https://github.com/classgraph/classgraph
+ *
+ * --
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Luke Hutchison
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.classgraph.issues.issue267;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class ClassLoadingWorksWithParentLastLoadersStub {
+
+	@Test
+	public void sameClassLoaderThatFoundAClassShouldLoadIt() throws Exception {
+		new ClassLoadingWorksWithParentLastLoaders().assertCorrectClassLoaders("AppClassLoader");
+
+		final TestLauncher launcher = new TestLauncher();
+		launcher.start();
+		launcher.join();
+	}
+}
+
+class TestLauncher extends Thread {
+
+	private Throwable error;
+
+	TestLauncher() {
+		setDaemon(false);
+		setContextClassLoader(new FakeRestartClassLoader());
+	}
+
+	@Override
+	public void run() {
+		try {
+			final Class<?> mainClass = getContextClassLoader().loadClass(
+				"io.github.classgraph.issues.issue267.ClassLoadingWorksWithParentLastLoaders");
+			final Method mainMethod = mainClass.getDeclaredMethod("assertCorrectClassLoaders", String.class);
+			mainMethod.invoke(mainClass.getDeclaredConstructor().newInstance(),
+				new Object[] { "FakeRestartClassLoader" });
+		} catch (Throwable ex) {
+			this.error = ex;
+			getUncaughtExceptionHandler().uncaughtException(this, ex);
+		}
+	}
+}
+
+class FakeRestartClassLoader extends ClassLoader {
+	private Class getClass(final String name) throws ClassNotFoundException {
+		try {
+			final byte[] b = loadClassFileData(name.replace('.', File.separatorChar) + ".class");
+			return defineClass(name, b, 0, b.length);
+		} catch (IOException e) {
+			throw new ClassNotFoundException(name);
+		}
+	}
+
+	@Override
+	public Class loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+		if (name.startsWith("com.xyz.meta.A") || name
+			.startsWith("io.github.classgraph.issues.issue267.ClassLoadingWorksWithParentLastLoaders")) {
+			Class clazz = getClass(name);
+			if (resolve) {
+				resolveClass(clazz);
+			}
+		}
+		return super.loadClass(name, resolve);
+	}
+
+	private byte[] loadClassFileData(final String name) throws IOException {
+		try (final DataInputStream in = new DataInputStream(getClass().getClassLoader().getResourceAsStream(name))) {
+			int size = in.available();
+			byte buff[] = new byte[size];
+			in.readFully(buff);
+			return buff;
+		}
+	}
+}


### PR DESCRIPTION
This commit has to changes:

- It introduces SpringBootRestartClassLoaderHandler and adds it to the registry. RestartClassLoader is parent last and such should be explicitly configured.
- The codewise small but impact wise bigger change is instantiating ClassGraphClassLoader with a call of super(null), eliminating it’s parent.

The later one is done due to the following reason:
ClassGraphClassLoader goes through lengths in `io.github.classgraph.ClassGraphClassLoader#findClass` to determine which class loader has been the source of the scanned class and that works very well.

`findClass` is however called from `loadClass` only if there is no parent class loader or the parent class loader doesn't find the class.

In Spring Boot together with Spring Boots Restart Class Loader we have the following situation:

A launcher thread spawns the actually application using the `RestartClassLoader` described in #267. 

From there on, all application classes (especially entities from OGM) live in the RestartClassLoader. 

ClassGraph finds them as well and also notices that they are part of RestartClassLoader.

however, `loadClass` always uses the parent class loader first if any and none of the class loaders that are determined in `findClass`. 

The main change here is not giving `ClassGraphClassLoader` a parent, thus forcing it to do the lookup by himself with the mechanism of findClass.

The rest are just tests.

* Create a Thread using another class loader (knowing only 2 classes)
* Run everything from that Thread and Class loader
* Create a test stub that is runnable from the above thread and also in a normal way (Boot devtools on and off)
* See if scanned classes are compatible with directly loaded classes.

If you have any questions or suggest that it would be better to solve this by also overwriting `loadClass`, I'm very happy to discuss.

This closes #267.