### PR TITLE
Add getDeclaredAnnotationInfo() and getDeclaredAnnotationInfo(String).

### DIFF
--- a/src/main/java/io/github/classgraph/ClassInfo.java
+++ b/src/main/java/io/github/classgraph/ClassInfo.java
@@ -1211,6 +1211,37 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
     // Annotations
 
     /**
+     * Returns information on visible methods declared by this class, but not by its interfaces or superclasses,
+     *
+     * <p>
+     * It does not include any the {@link Inherited} meta-annotation.
+     *
+     * @return A list of {@link AnnotationInfo} objects for the annotations on this class, or the empty list if
+     *         none.
+     */
+    public AnnotationInfoList getDeclaredAnnotationInfo() {
+        if (!scanResult.scanSpec.enableAnnotationInfo) {
+            throw new IllegalArgumentException("Please call ClassGraph#enableAnnotationInfo() before #scan()");
+        }
+        return annotationInfo == null ? AnnotationInfoList.EMPTY_LIST : annotationInfo;
+    }
+
+    /**
+     * Get a the named annotation on this class, or null if the class does not have the named annotation.
+     *
+     * <p>
+     * It does not include any the {@link Inherited} meta-annotation.
+     *
+     * @param annotationName
+     *            The annotation name.
+     * @return An {@link AnnotationInfo} object representing the named annotation on this class, or null if the
+     *         class does not have the named annotation.
+     */
+    public AnnotationInfo getDeclaredAnnotationInfo(final String annotationName) {
+        return getAnnotationInfo().get(annotationName);
+    }
+
+    /**
      * Get the annotations and meta-annotations on this class. (Call {@link #getAnnotationInfo()} instead, if you
      * need the parameter values of annotations, rather than just the annotation classes.)
      * 

--- a/src/test/java/io/github/classgraph/features/DeclaredVsNonDeclared.java
+++ b/src/test/java/io/github/classgraph/features/DeclaredVsNonDeclared.java
@@ -4,12 +4,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+import io.github.classgraph.AnnotationInfo;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ScanResult;
 
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.assertj.core.api.iterable.Extractor;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Inherited
+@interface InheritedAnnotation {
+}
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@interface NormalAnnotation {
+}
+
 public class DeclaredVsNonDeclared {
 
+    @NormalAnnotation
+    @InheritedAnnotation
     public abstract static class A {
         float x;
 
@@ -30,10 +48,14 @@ public class DeclaredVsNonDeclared {
         }
     }
 
+    @NormalAnnotation
+    public abstract static class C extends A {
+    }
+
     @Test
-    public void declaredVsNonDeclared() {
+    public void declaredVsNonDeclaredMethods() {
         try (ScanResult scanResult = new ClassGraph().enableAllInfo()
-                .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+            .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
             final ClassInfo A = scanResult.getClassInfo(A.class.getName());
             final ClassInfo B = scanResult.getClassInfo(B.class.getName());
             assertThat(B.getFieldInfo("x").getClassInfo().getName()).isEqualTo(B.class.getName());
@@ -41,15 +63,41 @@ public class DeclaredVsNonDeclared {
             assertThat(A.getFieldInfo().get(0).getTypeDescriptor().toString()).isEqualTo("float");
             assertThat(B.getFieldInfo().get(0).getTypeDescriptor().toString()).isEqualTo("int");
             assertThat(B.getMethodInfo().toString()).isEqualTo(
-                    "[void y(int, int), abstract void y(java.lang.String), abstract void y(java.lang.Integer)]");
+                "[void y(int, int), abstract void y(java.lang.String), abstract void y(java.lang.Integer)]");
             assertThat(B.getDeclaredMethodInfo().toString()).isEqualTo("[void y(int, int)]");
+        }
+    }
+
+    @Test
+    public void declaredVsNonDeclaredAnnotations() {
+        Extractor<AnnotationInfo, Object> annotationNameExtractor = new Extractor<AnnotationInfo, Object>() {
+            @Override
+            public Object extract(AnnotationInfo input) {
+                return input.getName();
+            }
+        };
+
+        try (ScanResult scanResult = new ClassGraph().enableAllInfo()
+            .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+            final ClassInfo A = scanResult.getClassInfo(A.class.getName());
+            final ClassInfo B = scanResult.getClassInfo(B.class.getName());
+            final ClassInfo C = scanResult.getClassInfo(C.class.getName());
+            assertThat(A.getAnnotationInfo()).extracting(annotationNameExtractor)
+                .containsExactly(NormalAnnotation.class.getName(), InheritedAnnotation.class.getName());
+            assertThat(B.getAnnotationInfo()).extracting(annotationNameExtractor)
+                .containsExactly(InheritedAnnotation.class.getName());
+            assertThat(A.getDeclaredAnnotationInfo()).extracting(annotationNameExtractor)
+                .containsExactly(NormalAnnotation.class.getName(), InheritedAnnotation.class.getName());
+            assertThat(B.getDeclaredAnnotationInfo()).isEmpty();
+            assertThat(C.getDeclaredAnnotationInfo()).extracting(annotationNameExtractor)
+                .containsExactly(NormalAnnotation.class.getName());
         }
     }
 
     @Test
     public void loadFieldAndMethod() {
         try (ScanResult scanResult = new ClassGraph().enableAllInfo()
-                .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+            .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
             final ClassInfo A = scanResult.getClassInfo(A.class.getName());
             final ClassInfo B = scanResult.getClassInfo(B.class.getName());
             assertThat(B.getFieldInfo("x").loadClassAndGetField().getName()).isEqualTo("x");


### PR DESCRIPTION
We would love to see a corresponding `getDeclaredAnnotationInfo` method that works the same way as with fields and methods (they already come in pairs as well). This PR adds this feature.