### PR TITLE
Add directOnly() to public API of AnnotationInfoList.

### DIFF
--- a/src/main/java/io/github/classgraph/ClassInfo.java
+++ b/src/main/java/io/github/classgraph/ClassInfo.java
@@ -1239,7 +1239,7 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
                 if (superclassAnnotations != null) {
                     // Check if any of the meta-annotations on this annotation are @Inherited,
                     // which causes an annotation to annotate a class and all of its subclasses.
-                    if (isInherited) {
+                    if (superclassAnnotationClass.isInherited) {
                         // inheritedSuperclassAnnotations is an inherited annotation
                         if (inheritedSuperclassAnnotations == null) {
                             inheritedSuperclassAnnotations = new LinkedHashSet<>();

--- a/src/main/java/io/github/classgraph/ClassInfo.java
+++ b/src/main/java/io/github/classgraph/ClassInfo.java
@@ -721,7 +721,7 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
     }
 
     /**
-     * Get all annotation classes found during the scan. See also {@link #getAllInterfaceOrAnnotationClasses()}.
+     * Get all annotation classes found during the scan. See also {@link #getAllInterfacesOrAnnotationClasses(Collection, ScanSpec, ScanResult)} ()}.
      *
      * @return A list of all annotation classes found during the scan, or the empty list if none.
      */
@@ -1228,7 +1228,6 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
         // Get all annotations on this class
         final ReachableAndDirectlyRelatedClasses annotationClasses = this.filterClassInfo(RelType.CLASS_ANNOTATIONS,
                 /* strictWhitelist = */ false);
-
         // Check for any @Inherited annotations on superclasses
         Set<ClassInfo> inheritedSuperclassAnnotations = null;
         for (final ClassInfo superclass : getSuperclasses()) {
@@ -1288,15 +1287,16 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
                 }
             }
         }
+
+        AnnotationInfoList directlyRelatedAnnotations = annotationInfo == null ? AnnotationInfoList.EMPTY_LIST : annotationInfo;
         if (inheritedSuperclassAnnotations == null) {
             // No inherited superclass annotations
-            return annotationInfo == null ? AnnotationInfoList.EMPTY_LIST : annotationInfo;
+            return directlyRelatedAnnotations;
         } else {
             // Merge inherited superclass annotations and annotations on this class
-            if (annotationInfo != null) {
-                inheritedSuperclassAnnotations.addAll(annotationInfo);
-            }
+            inheritedSuperclassAnnotations.addAll(directlyRelatedAnnotations);
             Collections.sort(inheritedSuperclassAnnotations);
+            inheritedSuperclassAnnotations = new AnnotationInfoList(inheritedSuperclassAnnotations, directlyRelatedAnnotations);
             return inheritedSuperclassAnnotations;
         }
     }

--- a/src/test/java/io/github/classgraph/features/DeclaredVsNonDeclared.java
+++ b/src/test/java/io/github/classgraph/features/DeclaredVsNonDeclared.java
@@ -4,12 +4,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+import io.github.classgraph.AnnotationInfo;
+import io.github.classgraph.AnnotationInfoList;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
 import io.github.classgraph.ScanResult;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.assertj.core.api.iterable.Extractor;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@Inherited
+@interface InheritedAnnotation {
+}
+
+@Retention(value = RetentionPolicy.RUNTIME)
+@interface NormalAnnotation {
+}
 
 public class DeclaredVsNonDeclared {
 
+    @NormalAnnotation
+    @InheritedAnnotation
     public abstract static class A {
         float x;
 
@@ -20,6 +40,9 @@ public class DeclaredVsNonDeclared {
         abstract void y(String x);
 
         abstract void y(Integer x);
+
+        @InheritedAnnotation
+        abstract void w();
     }
 
     public abstract static class B extends A {
@@ -28,12 +51,20 @@ public class DeclaredVsNonDeclared {
         @Override
         void y(final int x, final int y) {
         }
+
+        @Override
+        void w() {
+        }
+    }
+
+    @NormalAnnotation
+    public abstract static class C extends A {
     }
 
     @Test
-    public void declaredVsNonDeclared() {
+    public void declaredVsNonDeclaredMethods() {
         try (ScanResult scanResult = new ClassGraph().enableAllInfo()
-                .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+            .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
             final ClassInfo A = scanResult.getClassInfo(A.class.getName());
             final ClassInfo B = scanResult.getClassInfo(B.class.getName());
             assertThat(B.getFieldInfo("x").getClassInfo().getName()).isEqualTo(B.class.getName());
@@ -41,15 +72,35 @@ public class DeclaredVsNonDeclared {
             assertThat(A.getFieldInfo().get(0).getTypeDescriptor().toString()).isEqualTo("float");
             assertThat(B.getFieldInfo().get(0).getTypeDescriptor().toString()).isEqualTo("int");
             assertThat(B.getMethodInfo().toString()).isEqualTo(
-                    "[void y(int, int), abstract void y(java.lang.String), abstract void y(java.lang.Integer)]");
-            assertThat(B.getDeclaredMethodInfo().toString()).isEqualTo("[void y(int, int)]");
+                "[void y(int, int), void w(), abstract void y(java.lang.String), abstract void y(java.lang.Integer)]");
+            assertThat(B.getDeclaredMethodInfo().toString()).isEqualTo("[void y(int, int), void w()]");
+        }
+    }
+
+    @Test
+    public void annotationsShouldBeAbleToDifferentiateBetweenDirectAndReachable() {
+        try (ScanResult scanResult = new ClassGraph().enableAllInfo()
+            .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+            final ClassInfo A = scanResult.getClassInfo(A.class.getName());
+            final ClassInfo B = scanResult.getClassInfo(B.class.getName());
+
+            final ClassInfoList annotationsOnA = A.getAnnotations();
+            final ClassInfoList annotationsOnB = B.getAnnotations();
+
+            assertThat(annotationsOnA.loadClasses())
+                .containsExactlyInAnyOrder(NormalAnnotation.class, InheritedAnnotation.class);
+            assertThat(annotationsOnB.loadClasses())
+                .containsExactlyInAnyOrder(InheritedAnnotation.class);
+            assertThat(annotationsOnA.directOnly().loadClasses())
+                .containsExactlyInAnyOrder(NormalAnnotation.class, InheritedAnnotation.class);
+            assertThat(annotationsOnB.directOnly()).isEmpty();
         }
     }
 
     @Test
     public void loadFieldAndMethod() {
         try (ScanResult scanResult = new ClassGraph().enableAllInfo()
-                .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+            .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
             final ClassInfo A = scanResult.getClassInfo(A.class.getName());
             final ClassInfo B = scanResult.getClassInfo(B.class.getName());
             assertThat(B.getFieldInfo("x").loadClassAndGetField().getName()).isEqualTo("x");


### PR DESCRIPTION
This allows to filter the list of annotations to direct annotations only. Those are
all annotations directly declared on a element.

The only case directOnly can deliver something else are classes that inherited classes
annotated with meta-annotated @Inherited annotations.

*Note* This PR is rebased onto my branch `fix-retrieval-of-annotation-classes` and should be merged after #271 is merged.

Closes #270 in favor of this PR.