### PR TITLE
Export utils as well (#273).

### DIFF
--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,4 +1,6 @@
 module io.github.classgraph {
     exports io.github.classgraph;
+    exports io.github.classgraph.utils;
+
     uses io.github.classgraph.ClassLoaderHandler;
 }


### PR DESCRIPTION
You have to export the utils package as well, otherwise the calling site on the module path cannot implement a custom class loader handler. See attached example.

[classgraphtest-issue273.zip](https://github.com/classgraph/classgraph/files/2522966/classgraphtest-issue273.zip)
