### PR TITLE
Fix field name in EquinoxClassLoaderHandler to nestedDirName

### DIFF
--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/EquinoxClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/EquinoxClassLoaderHandler.java
@@ -45,7 +45,7 @@ import nonapi.io.github.classgraph.utils.ReflectionUtils;
 public class EquinoxClassLoaderHandler implements ClassLoaderHandler {
 
     private static final List<String> FIELD_NAMES = Collections
-            .unmodifiableList(Arrays.asList("cp", "bundleDirName"));
+            .unmodifiableList(Arrays.asList("cp", "nestedDirName"));
     private boolean readSystemBundles = false;
 
     @Override


### PR DESCRIPTION
Hey @lukehutch I'm terribly sorry about it, but I've made a mistake on one of the field names that I've added yesterday by accidentally copy pasting an incorrect field name. My mistake doesn't cause any issues with previous versions of equinox class path resolving. 

This pull request aims to fix the issue above. I hope I haven't ruined anything and thank you for responding and releasing my fix yesterday so fast.

Kind Regards,
Zoltán Molnár