### PR TITLE
Remove oraclejdk-ea from Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ jdk:
   - openjdk11     # LTS
 #  - oraclejdk11
   - openjdk-ea    # Early access
-#  - oraclejdk-ea
 
 sudo: true  # https://github.com/travis-ci/travis-ci/issues/6593
 


### PR DESCRIPTION
Oracle won't provide "early access" versions as "oraclejdk".  They do offer early access versions by providing "openjdk-ea":

> [...] we don't have an Oracle JDK 12 EA because it's literally the same as our OpenJDK builds, so we likely won't have Oracle JDK ea builds any more now, just GPL ones.

https://twitter.com/DonaldOJDK/status/1032638250899390465

See https://github.com/sormuras/bach/issues/33 for details.