### PR TITLE
ClassGraph doesn’t run on a read-only file system

### DIFF
--- a/src/main/java/io/github/classgraph/ScanResult.java
+++ b/src/main/java/io/github/classgraph/ScanResult.java
@@ -36,7 +36,6 @@ import java.io.RandomAccessFile;
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;

--- a/src/main/java/io/github/classgraph/ScanResult.java
+++ b/src/main/java/io/github/classgraph/ScanResult.java
@@ -243,12 +243,8 @@ public final class ScanResult implements Closeable, AutoCloseable {
             }
             boolean foundReadableClasspathEntry = false;
             for (final String classpathEntry : JarUtils.smartPathSplit(classpath)) {
-                try {
-                    tempFile = new File(new URI(classpathEntry));
-                } catch (final URISyntaxException e2) {
-                    continue;
-                }
-                if (FileUtils.canRead(tempFile)) {
+                tempFile = new File(classpathEntry);
+                if (FileUtils.canRead(tempFile) && tempFile.isFile()) {
                     // Found a readable file
                     foundReadableClasspathEntry = true;
                     break;


### PR DESCRIPTION
ClassGraph crashes while scanning when running on an read-only file system.

This is easily reproducible by running
```java
public class Main {
    public static void main(String... args) {
        new ClassGraph().scan();
    }
}
```

with `java -Djava.io.tmpdir=/nonexistent`, even `ScanResult.fromJSON("");` triggers the bug.

The culprit is in the [static initializer of ScanResult](https://github.com/classgraph/classgraph/blob/72ecfa093ae685ae66d44a629772eacfaa91836d/src/main/java/io/github/classgraph/ScanResult.java#L247):
```java
            for (final String classpathEntry : JarUtils.smartPathSplit(classpath)) {
                try {
                    tempFile = new File(new URI(classpathEntry));
                } catch (final URISyntaxException e2) {
                    continue;
                }
                if (FileUtils.canRead(tempFile)) {
                    // Found a readable file
                    foundReadableClasspathEntry = true;
                    break;
                }
            }
```

`new URI(classpathEntry)` has no scheme, so `File` bails with an `IllegalArgumentException`: “URI is not absolute”.

While `new URI("file://" + classpathEntry)` kind of works, I would suggest:

```java
            for (final String classpathEntry : JarUtils.smartPathSplit(classpath)) {
                tempFile = new File(classpathEntry);
                if (FileUtils.canRead(tempFile) && tempFile.isFile()) {
                    // Found a readable file
                    foundReadableClasspathEntry = true;
                    break;
                }
            }
```

This also skips readable directories in the classpath, since the file should be opened for reading later. Also

```java
import java.net.URISyntaxException;
```

is no longer needed.