### PR TITLE
Fixed exception during loading of method with array-type arguments

### DIFF
--- a/src/main/java/io/github/classgraph/AnnotationEnumValue.java
+++ b/src/main/java/io/github/classgraph/AnnotationEnumValue.java
@@ -105,6 +105,9 @@ public class AnnotationEnumValue extends ScanResultObject implements Comparable<
      */
     public Object loadClassAndReturnEnumValue(final boolean ignoreExceptions) throws IllegalArgumentException {
         final Class<?> classRef = super.loadClass(ignoreExceptions);
+		if (classRef == null) {
+			return null;
+		}
         if (!classRef.isEnum()) {
             throw new IllegalArgumentException("Class " + className + " is not an enum");
         }

--- a/src/main/java/io/github/classgraph/ArrayTypeSignature.java
+++ b/src/main/java/io/github/classgraph/ArrayTypeSignature.java
@@ -40,6 +40,9 @@ public class ArrayTypeSignature extends ReferenceTypeSignature {
 
     /** The number of array dimensions. */
     private final int numDims;
+    
+    /** Class name. */
+    private final String className;
 
     // -------------------------------------------------------------------------------------------------------------
 
@@ -50,11 +53,14 @@ public class ArrayTypeSignature extends ReferenceTypeSignature {
      *            The type signature of the array elements.
      * @param numDims
      *            The number of array dimensions.
+     * @param className
+     *            Raw name of array type (like "[[B")
      */
-    ArrayTypeSignature(final TypeSignature elementTypeSignature, final int numDims) {
+    ArrayTypeSignature(final TypeSignature elementTypeSignature, final int numDims, final String className) {
         super();
         this.elementTypeSignature = elementTypeSignature;
         this.numDims = numDims;
+        this.className = className;
     }
 
     /**
@@ -82,8 +88,7 @@ public class ArrayTypeSignature extends ReferenceTypeSignature {
      */
     @Override
     protected String getClassName() {
-        // getClassInfo() is not valid for this type, so getClassName() does not need to be implemented
-        throw new IllegalArgumentException("getClassName() cannot be called here");
+    	return className;
     }
 
     /* (non-Javadoc)
@@ -180,6 +185,7 @@ public class ArrayTypeSignature extends ReferenceTypeSignature {
      */
     static ArrayTypeSignature parse(final Parser parser, final String definingClassName) throws ParseException {
         int numArrayDims = 0;
+        int begin = parser.getPosition();
         while (parser.peek() == '[') {
             numArrayDims++;
             parser.next();
@@ -189,7 +195,8 @@ public class ArrayTypeSignature extends ReferenceTypeSignature {
             if (elementTypeSignature == null) {
                 throw new ParseException(parser, "elementTypeSignature == null");
             }
-            return new ArrayTypeSignature(elementTypeSignature, numArrayDims);
+            CharSequence cn = parser.getSubsequence(begin, parser.getPosition());
+            return new ArrayTypeSignature(elementTypeSignature, numArrayDims, cn.toString());
         } else {
             return null;
         }

--- a/src/main/java/io/github/classgraph/MethodInfo.java
+++ b/src/main/java/io/github/classgraph/MethodInfo.java
@@ -842,7 +842,7 @@ public class MethodInfo extends ScanResultObject implements Comparable<MethodInf
                             "Got a zero-dimension array type for last parameter of varargs method " + name);
                 }
                 buf.append(new ArrayTypeSignature(arrayType.getElementTypeSignature(),
-                        arrayType.getNumDimensions() - 1).toString());
+                        arrayType.getNumDimensions() - 1, arrayType.getClassName()).toString());
                 buf.append("...");
             } else {
                 buf.append(paramType.toString());

--- a/src/main/java/io/github/classgraph/ScanResultObject.java
+++ b/src/main/java/io/github/classgraph/ScanResultObject.java
@@ -111,7 +111,12 @@ abstract class ScanResultObject {
      */
     private String getClassInfoNameOrClassName() {
         String className;
-        ClassInfo ci = getClassInfo();
+        ClassInfo ci = null;
+		try {
+			ci = getClassInfo();
+		} catch(IllegalArgumentException e) {
+			// Just ignore wrong access to array classInfo
+		}
         if (ci == null) {
             ci = classInfo;
         }

--- a/src/test/java/io/github/classgraph/test/methodinfo/MethodInfoTest.java
+++ b/src/test/java/io/github/classgraph/test/methodinfo/MethodInfoTest.java
@@ -29,7 +29,9 @@
 package io.github.classgraph.test.methodinfo;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 import org.junit.Test;
@@ -103,7 +105,7 @@ public class MethodInfoTest {
                         @Override
                         public boolean accept(final MethodInfo methodInfo) {
                             // JDK 10 fix
-                            return !methodInfo.getName().equals("$closeResource");
+                            return !methodInfo.getName().equals("$closeResource") && !methodInfo.getName().equals("lambda$0") && !methodInfo.isSynthetic();
                         }
                     }).getAsStrings()).containsExactlyInAnyOrder( //
                             "@" + ExternalAnnotation.class.getName() //
@@ -118,7 +120,10 @@ public class MethodInfoTest {
                             "@" + Test.class.getName() + "(expected=class org.junit.Test$None, timeout=0) "
                                     + "public void testGetConstructorInfo()",
                             "@" + Test.class.getName() + "(expected=class org.junit.Test$None, timeout=0) "
-                                    + "public void testGetMethodInfoIgnoringVisibility()");
+                                    + "public void testGetMethodInfoIgnoringVisibility()",
+                            "@" + Test.class.getName() + "(expected=class org.junit.Test$None, timeout=0) "
+                                    + "public void testMethodInfoLoadMethodForArrayArg()"
+                            );
         }
     }
 
@@ -146,7 +151,7 @@ public class MethodInfoTest {
                         @Override
                         public boolean accept(final MethodInfo methodInfo) {
                             // JDK 10 fix
-                            return !methodInfo.getName().equals("$closeResource");
+                            return !methodInfo.getName().equals("$closeResource") && !methodInfo.getName().equals("lambda$0") && !methodInfo.isSynthetic();
                         }
                     }).getAsStrings()).containsExactlyInAnyOrder( //
                             "@" + ExternalAnnotation.class.getName() //
@@ -162,7 +167,27 @@ public class MethodInfoTest {
                             "@" + Test.class.getName() + "(expected=class org.junit.Test$None, timeout=0) "
                                     + "public void testGetConstructorInfo()",
                             "@" + Test.class.getName() + "(expected=class org.junit.Test$None, timeout=0) "
-                                    + "public void testGetMethodInfoIgnoringVisibility()");
+                                    + "public void testGetMethodInfoIgnoringVisibility()",
+                            "@" + Test.class.getName() + "(expected=class org.junit.Test$None, timeout=0) "
+                                    + "public void testMethodInfoLoadMethodForArrayArg()"
+                            );
+        }
+    }
+    
+    /**
+     * MethodInfo.loadClassAndGetMethod for arrays argument
+     */
+    @Test
+    public void testMethodInfoLoadMethodForArrayArg() {
+    	try (ScanResult scanResult = new ClassGraph().whitelistPackages(MethodInfoTest.class.getPackage().getName())
+                .enableClassInfo().enableMethodInfo().enableAnnotationInfo().scan()) {
+    		MethodInfo mi = scanResult.getClassInfo(MethodInfoTest.class.getName()).getMethodInfo()
+    				.getSingleMethod("publicMethodWithArgs");
+    		assertThat(mi).isNotNull();
+    		assertThatCode(() -> {
+    			mi.loadClassAndGetMethod();
+    			}).doesNotThrowAnyException();
+    		assertThat(mi.loadClassAndGetMethod()).isNotNull(); 
         }
     }
 }


### PR DESCRIPTION
Hi Luke,
Added class name to ArrayTypeSignature accordingly to https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getName() (actually, it is just parser input)
Tested on Java 11

Regards