### PR TITLE
Fix classpath detection for nested ZipBundleFile

### DIFF
--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/EquinoxClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/EquinoxClassLoaderHandler.java
@@ -28,18 +28,14 @@
  */
 package nonapi.io.github.classgraph.classloaderhandler;
 
-import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import nonapi.io.github.classgraph.classpath.ClassLoaderOrder;
 import nonapi.io.github.classgraph.classpath.ClasspathOrder;
 import nonapi.io.github.classgraph.scanspec.ScanSpec;
 import nonapi.io.github.classgraph.utils.LogNode;
 import nonapi.io.github.classgraph.utils.ReflectionUtils;
+
+import java.lang.reflect.Array;
+import java.util.*;
 
 /**
  * Extract classpath entries from the Eclipse Equinox ClassLoader.
@@ -114,7 +110,16 @@ class EquinoxClassLoaderHandler implements ClassLoaderHandler {
                     foundClassPathElement = fieldVal != null;
                     if (foundClassPathElement) {
                         // We found the base file and a classpath element, e.g. "bin/"
-                        classpathOrderOut.addClasspathEntry(basefile.toString() + "/" + fieldVal.toString(),
+                        String pathElement = basefile.toString() + "/" + fieldVal.toString();
+
+                        if (bundlefile.getClass().getName().equals("org.eclipse.osgi.storage.bundlefile.NestedDirBundleFile")) {
+                            Object baseBundleFile = ReflectionUtils.getFieldVal(bundlefile, "baseBundleFile", false);
+                            if (baseBundleFile != null && baseBundleFile.getClass().getName().equals("org.eclipse.osgi.storage.bundlefile.ZipBundleFile")) {
+                                pathElement = baseBundleFile.toString() + "!/" + fieldVal.toString();
+                            }
+                        }
+
+                        classpathOrderOut.addClasspathEntry(pathElement,
                                 classLoader, scanSpec, log);
                         break;
                     }


### PR DESCRIPTION
If a `NestedBundleFile` contains a `ZipBundleFile` their paths must be concatenated using `!/` instead of `/`.