### PR TITLE
Change visibility of EMPTY_LIST to use it for initialization.

### DIFF
--- a/src/main/java/io/github/classgraph/ClassInfoList.java
+++ b/src/main/java/io/github/classgraph/ClassInfoList.java
@@ -124,7 +124,7 @@ public class ClassInfoList extends MappableInfoList<ClassInfo> {
     }
 
     /** An unmodifiable empty {@link ClassInfoList}. */
-    static final ClassInfoList EMPTY_LIST = new ClassInfoList() {
+    public static final ClassInfoList EMPTY_LIST = new ClassInfoList() {
         @Override
         public boolean add(final ClassInfo e) {
             throw new IllegalArgumentException("List is immutable");


### PR DESCRIPTION
This change is to improve chainability of ClassInfoList results when combining multiple together. Does not affect immutability of ClassInfoList.

Old code:
```
    ClassInfoList classes = null;
    try (ScanResult scanResult = new ClassGraph()
        .whitelistPackages(testClass.getPackage().getName())
        .scan()) {
          for (Class<?> clazz : this.ofTypes) {
            if (clazz.isInterface()) {
              ClassInfoList cil = scanResult
                  .getClassesImplementing(clazz.getName());
              classes = classes == null ? cil : classes.union(cil);
            } else {
              ClassInfoList cil = scanResult
                  .getSubclasses(clazz.getName());
              cil.add(scanResult.getClassInfo(clazz.getName()));
              classes = classes == null ? cil : classes.union(cil);
            }
          }
    }
```

New code:
```
    ClassInfoList classes = ClassInfoList.EMPTY_LIST;
    try (ScanResult scanResult = new ClassGraph()
        .whitelistPackages(testClass.getPackage().getName())
        .scan()) {
          for (Class<?> clazz : this.ofTypes) {
            if (clazz.isInterface()) {
              ClassInfoList cil = scanResult
                  .getClassesImplementing(clazz.getName());
              classes = classes.union(cil);
            } else {
              ClassInfoList cil = scanResult
                  .getSubclasses(clazz.getName());
              cil.add(scanResult.getClassInfo(clazz.getName()));
              classes = classes.union(cil);
            }
          }
    }
```