### PR TITLE
rename some tests not run by maven

### DIFF
--- a/src/test/java/io/github/classgraph/features/AnnotationEqualityTest.java
+++ b/src/test/java/io/github/classgraph/features/AnnotationEqualityTest.java
@@ -16,7 +16,7 @@ import io.github.classgraph.ScanResult;
 /**
  * AnnotationEquality.
  */
-public class AnnotationEquality {
+public class AnnotationEqualityTest {
     /**
      * The Interface W.
      */
@@ -72,7 +72,7 @@ public class AnnotationEquality {
     /**
      * The Class Y.
      */
-    @X(b = 5, c = { Long.class, Integer.class, AnnotationEquality.class, W.class, X.class }
+    @X(b = 5, c = { Long.class, Integer.class, AnnotationEqualityTest.class, W.class, X.class }
     // , d = "xyz", e = 'w'
     )
     private static class Y {
@@ -84,7 +84,7 @@ public class AnnotationEquality {
     @Test
     public void annotationEquality() {
         try (ScanResult scanResult = new ClassGraph()
-                .whitelistPackages(AnnotationEquality.class.getPackage().getName()).enableAllInfo().scan()) {
+                .whitelistPackages(AnnotationEqualityTest.class.getPackage().getName()).enableAllInfo().scan()) {
             final ClassInfo classInfo = scanResult.getClassInfo(Y.class.getName());
             assertThat(classInfo).isNotNull();
             final Class<?> cls = classInfo.loadClass();

--- a/src/test/java/io/github/classgraph/features/AnnotationParamWithPrimitiveTypedArrayTest.java
+++ b/src/test/java/io/github/classgraph/features/AnnotationParamWithPrimitiveTypedArrayTest.java
@@ -16,7 +16,7 @@ import io.github.classgraph.ScanResult;
 /**
  * AnnotationParamWithPrimitiveTypedArray.
  */
-public class AnnotationParamWithPrimitiveTypedArray {
+public class AnnotationParamWithPrimitiveTypedArrayTest {
     /**
      * The Interface NestedAnnotation.
      */
@@ -94,7 +94,7 @@ public class AnnotationParamWithPrimitiveTypedArray {
     @Test
     public void primitiveArrayParams() {
         try (ScanResult scanResult = new ClassGraph().enableAllInfo()
-                .whitelistPackages(AnnotationParamWithPrimitiveTypedArray.class.getPackage().getName()).scan()) {
+                .whitelistPackages(AnnotationParamWithPrimitiveTypedArrayTest.class.getPackage().getName()).scan()) {
             final AnnotationInfo annotationInfo = scanResult.getClassInfo(AnnotatedClass.class.getName())
                     .getAnnotationInfo().get(0);
             final AnnotationParameterValueList annotationParams = annotationInfo.getParameterValues();

--- a/src/test/java/io/github/classgraph/features/DeclaredVsNonDeclaredTest.java
+++ b/src/test/java/io/github/classgraph/features/DeclaredVsNonDeclaredTest.java
@@ -39,7 +39,7 @@ import io.github.classgraph.ScanResult;
 /**
  * DeclaredVsNonDeclared.
  */
-public class DeclaredVsNonDeclared {
+public class DeclaredVsNonDeclaredTest {
     /**
      * The Class A.
      */
@@ -122,7 +122,7 @@ public class DeclaredVsNonDeclared {
     @Test
     public void declaredVsNonDeclaredMethods() {
         try (ScanResult scanResult = new ClassGraph().enableAllInfo()
-                .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+                .whitelistPackages(DeclaredVsNonDeclaredTest.class.getPackage().getName()).scan()) {
             final ClassInfo A = scanResult.getClassInfo(A.class.getName());
             final ClassInfo B = scanResult.getClassInfo(B.class.getName());
             assertThat(B.getFieldInfo("x").getClassInfo().getName()).isEqualTo(B.class.getName());
@@ -148,7 +148,7 @@ public class DeclaredVsNonDeclared {
         };
 
         try (ScanResult scanResult = new ClassGraph().enableAllInfo()
-                .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+                .whitelistPackages(DeclaredVsNonDeclaredTest.class.getPackage().getName()).scan()) {
             final ClassInfo A = scanResult.getClassInfo(A.class.getName());
             final ClassInfo B = scanResult.getClassInfo(B.class.getName());
             final ClassInfo C = scanResult.getClassInfo(C.class.getName());
@@ -190,7 +190,7 @@ public class DeclaredVsNonDeclared {
     @Test
     public void annotationsShouldBeAbleToDifferentiateBetweenDirectAndReachable() {
         try (ScanResult scanResult = new ClassGraph().enableAllInfo()
-                .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+                .whitelistPackages(DeclaredVsNonDeclaredTest.class.getPackage().getName()).scan()) {
             final ClassInfo A = scanResult.getClassInfo(A.class.getName());
             final ClassInfo B = scanResult.getClassInfo(B.class.getName());
 
@@ -213,7 +213,7 @@ public class DeclaredVsNonDeclared {
     @Test
     public void loadFieldAndMethod() {
         try (ScanResult scanResult = new ClassGraph().enableAllInfo()
-                .whitelistPackages(DeclaredVsNonDeclared.class.getPackage().getName()).scan()) {
+                .whitelistPackages(DeclaredVsNonDeclaredTest.class.getPackage().getName()).scan()) {
             final ClassInfo B = scanResult.getClassInfo(B.class.getName());
             assertThat(B.getFieldInfo("x").loadClassAndGetField().getName()).isEqualTo("x");
             assertThat(B.getMethodInfo("y").get(0).loadClassAndGetMethod().getName()).isEqualTo("y");

--- a/src/test/java/io/github/classgraph/features/MethodParameterAnnotationsTest.java
+++ b/src/test/java/io/github/classgraph/features/MethodParameterAnnotationsTest.java
@@ -13,7 +13,7 @@ import io.github.classgraph.ScanResult;
 /**
  * AnnotationEquality.
  */
-public class MethodParameterAnnotations {
+public class MethodParameterAnnotationsTest {
     /**
      * The Annotation W.
      */
@@ -62,7 +62,7 @@ public class MethodParameterAnnotations {
     @Test
     public void annotationEquality() {
         try (ScanResult scanResult = new ClassGraph()
-                .whitelistPackages(MethodParameterAnnotations.class.getPackage().getName()).enableAllInfo()
+                .whitelistPackages(MethodParameterAnnotationsTest.class.getPackage().getName()).enableAllInfo()
                 .scan()) {
             assertThat(scanResult.getClassInfo(Y.class.getName()).getMethodParameterAnnotations().getNames())
                     .containsOnly(W.class.getName());

--- a/src/test/java/io/github/classgraph/features/MultiReleaseJarTest.java
+++ b/src/test/java/io/github/classgraph/features/MultiReleaseJarTest.java
@@ -20,9 +20,9 @@ import nonapi.io.github.classgraph.utils.VersionFinder;
 /**
  * MultiReleaseJar.
  */
-public class MultiReleaseJar {
+public class MultiReleaseJarTest {
     /** The Constant jarURL. */
-    private static final URL jarURL = MultiReleaseJar.class.getClassLoader().getResource("multi-release-jar.jar");
+    private static final URL jarURL = MultiReleaseJarTest.class.getClassLoader().getResource("multi-release-jar.jar");
 
     /**
      * Multi release jar.

--- a/src/test/java/io/github/classgraph/issues/ResolveTypeVariableTest.java
+++ b/src/test/java/io/github/classgraph/issues/ResolveTypeVariableTest.java
@@ -17,7 +17,7 @@ import io.github.classgraph.TypeVariableSignature;
  * @param <T>
  *            the generic type
  */
-public class ResolveTypeVariable<T extends ArrayList<Integer>> {
+public class ResolveTypeVariableTest<T extends ArrayList<Integer>> {
     /** The list. */
     T list;
 
@@ -27,8 +27,8 @@ public class ResolveTypeVariable<T extends ArrayList<Integer>> {
     @Test
     public void test() {
         try (ScanResult scanResult = new ClassGraph()
-                .whitelistPackages(ResolveTypeVariable.class.getPackage().getName()).enableAllInfo().scan()) {
-            final FieldInfoList fields = scanResult.getClassInfo(ResolveTypeVariable.class.getName())
+                .whitelistPackages(ResolveTypeVariableTest.class.getPackage().getName()).enableAllInfo().scan()) {
+            final FieldInfoList fields = scanResult.getClassInfo(ResolveTypeVariableTest.class.getName())
                     .getFieldInfo();
             assertThat(((TypeVariableSignature) fields.get(0).getTypeSignature()).resolve().toString())
                     .isEqualTo("T extends java.util.ArrayList<java.lang.Integer>");

--- a/src/test/java/io/github/classgraph/issues/issue267/ClassLoadingWorksWithParentLastLoadersStubTest.java
+++ b/src/test/java/io/github/classgraph/issues/issue267/ClassLoadingWorksWithParentLastLoadersStubTest.java
@@ -41,7 +41,7 @@ import com.xyz.meta.A;
 /**
  * ClassLoadingWorksWithParentLastLoadersStub.
  */
-public class ClassLoadingWorksWithParentLastLoadersStub {
+public class ClassLoadingWorksWithParentLastLoadersStubTest {
 
     /**
      * Same class loader that found A class should load it.


### PR DESCRIPTION
I have found that some tests in projects does not start or end with `Test` and so are not run by maven. So there are `Tests run: 127` in report, and after renaming tests `Tests run: 138`.

Unfortunately one of these tests is not stable - it relies on not standardized implementation-specific `toString()` implementation of Annotation from stdlib. Locally I have it passing in the IDE, but failing from terminal (seemingly on one and the same JDK, but maybe maven catches some other)

Is this situation an accident? 

 