### PR TITLE
Enable remote jar scanning for URLs inside URLClassLoader.

### DIFF
--- a/src/main/java/io/github/classgraph/Scanner.java
+++ b/src/main/java/io/github/classgraph/Scanner.java
@@ -35,6 +35,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -431,9 +432,9 @@ class Scanner implements Callable<ScanResult> {
                         if ("file".equals(scheme)) {
                             // Extract file path, and use below as a path string to determine if this
                             // classpath element is a file (jar) or directory
-                            classpathEntryPath = classpathEntryObj instanceof URL
+                            classpathEntryPath = URLDecoder.decode(classpathEntryObj instanceof URL
                                     ? ((URL) classpathEntryObj).getPath()
-                                    : ((URI) classpathEntryObj).getPath();
+                                    : ((URI) classpathEntryObj).getPath(), "UTF-8");
                         } else if ("http".equals(scheme) || "https".equals(scheme)) {
                             // Jar URL or URI (remote URLs/URIs must be jars)
                             return new ClasspathElementZip(classpathEntryObj, classpathEntry.classLoader,

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/URLClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/URLClassLoaderHandler.java
@@ -89,7 +89,7 @@ class URLClassLoaderHandler implements ClassLoaderHandler {
         if (urls != null) {
             for (final URL url : urls) {
                 if (url != null) {
-                    classpathOrder.addClasspathEntry(url.toString(), classLoader, scanSpec, log);
+                    classpathOrder.addClasspathEntry(url, classLoader, scanSpec, log);
                 }
             }
         }

--- a/src/test/java/io/github/classgraph/issues/issue387/Issue387Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue387/Issue387Test.java
@@ -26,12 +26,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package io.github.classgraph.issues.issue384;
+package io.github.classgraph.issues.issue387;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.*;
 import java.util.AbstractMap.SimpleEntry;
 
 import io.github.classgraph.features.CustomURLScheme;
@@ -44,7 +43,7 @@ import io.github.classgraph.ScanResult;
 /**
  * Test.
  */
-class Issue384Test {
+class Issue387Test {
     @BeforeAll
     static void setup() {
         new CustomURLScheme();
@@ -54,11 +53,15 @@ class Issue384Test {
      * Test.
      */
     @Test
-    void issue384Test() throws MalformedURLException {
-        final String filePath = Issue384Test.class.getClassLoader().getResource("nested-jars-level1.zip").getPath();
+    void issue387Test() throws MalformedURLException {
+        final String filePath = Issue387Test.class.getClassLoader().getResource("nested-jars-level1.zip").getPath();
         final String customSchemeURL = CustomURLScheme.SCHEME + ":" + filePath;
         final URL url = new URL(customSchemeURL);
-        try (ScanResult scanResult = new ClassGraph().enableRemoteJarScanning().overrideClasspath(url).scan()) {
+        final URLClassLoader classLoader = new URLClassLoader(new URL[] { url }, null);
+        try (ScanResult scanResult = new ClassGraph()
+                .enableRemoteJarScanning()
+                .overrideClassLoaders(classLoader)
+                .scan()) {
             assertThat(scanResult.getAllResources().getPaths()).containsExactly("level2.jar");
             assertThat(CustomURLScheme.remappedURLs.entrySet().iterator().next())
                     .isEqualTo(new SimpleEntry<>(customSchemeURL, "file:" + filePath));


### PR DESCRIPTION
This allows scanning of URLs that use a custom scheme.

I've refactored `CustomURLScheme` into a separate class because
`URL.setURLStreamHandlerFactory()` can only be invoked _once_ for a given JVM.