### PR TITLE
Add cause to IllegalArgumentException thrown by ScanResult.loadClass()

### DIFF
--- a/src/main/java/io/github/classgraph/ScanResult.java
+++ b/src/main/java/io/github/classgraph/ScanResult.java
@@ -1220,7 +1220,7 @@ public final class ScanResult implements Closeable, AutoCloseable {
             if (returnNullIfClassNotFound) {
                 return null;
             } else {
-                throw new IllegalArgumentException("Could not load class " + className + " : " + e);
+                throw new IllegalArgumentException("Could not load class " + className + " : " + e, e);
             }
         }
     }


### PR DESCRIPTION
adding the cause to the IllegalArgumentException thrown by ScanResult.loadClass() allows to programmatically handle different error cases