### PR TITLE
Add typed overloads for methods taking class names

### DIFF
--- a/src/main/java/io/github/classgraph/AnnotationInfoList.java
+++ b/src/main/java/io/github/classgraph/AnnotationInfoList.java
@@ -28,6 +28,7 @@
  */
 package io.github.classgraph;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 import io.github.classgraph.ClassInfo.RelType;
+import nonapi.io.github.classgraph.utils.Assert;
 import nonapi.io.github.classgraph.utils.CollectionUtils;
 import nonapi.io.github.classgraph.utils.LogNode;
 
@@ -343,6 +345,17 @@ public class AnnotationInfoList extends MappableInfoList<AnnotationInfo> {
     }
 
     // -------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Get the {@link Repeatable} annotation with the given class, or the empty list if none found.
+     *
+     * @param annotationClass The class to search for.
+     * @return The list of annotations with the given class, or the empty list if none found.
+     */
+    public AnnotationInfoList getRepeatable(final Class<? extends Annotation> annotationClass) {
+        Assert.isAnnotation(annotationClass);
+        return getRepeatable(annotationClass.getName());
+    }
 
     /**
      * Get the {@link Repeatable} annotation with the given name, or the empty list if none found.

--- a/src/main/java/io/github/classgraph/ClassInfo.java
+++ b/src/main/java/io/github/classgraph/ClassInfo.java
@@ -29,6 +29,7 @@
 package io.github.classgraph;
 
 import java.io.File;
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.reflect.Modifier;
@@ -56,6 +57,7 @@ import nonapi.io.github.classgraph.types.ParseException;
 import nonapi.io.github.classgraph.types.Parser;
 import nonapi.io.github.classgraph.types.TypeUtils;
 import nonapi.io.github.classgraph.types.TypeUtils.ModifierType;
+import nonapi.io.github.classgraph.utils.Assert;
 import nonapi.io.github.classgraph.utils.LogNode;
 
 /** Holds metadata about a class encountered during a scan. */
@@ -1292,6 +1294,16 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
     }
 
     /**
+     * Checks if this class extends the superclass.
+     *
+     * @param superclass A superclass.
+     * @return true if this class extends the superclass.
+     */
+    public boolean extendsSuperclass(final Class<?> superclass) {
+        return extendsSuperclass(superclass.getName());
+    }
+
+    /**
      * Checks if this class extends the named superclass.
      *
      * @param superclassName
@@ -1349,6 +1361,17 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
     }
 
     /**
+     * Checks whether this class implements the interface.
+     *
+     * @param interfaceClazz An interface.
+     * @return true if this class implements the interface.
+     */
+    public boolean implementsInterface(final Class<?> interfaceClazz) {
+        Assert.isInterface(interfaceClazz);
+        return implementsInterface(interfaceClazz.getName());
+    }
+
+    /**
      * Checks whether this class implements the named interface.
      *
      * @param interfaceName
@@ -1357,6 +1380,17 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
      */
     public boolean implementsInterface(final String interfaceName) {
         return getInterfaces().containsName(interfaceName);
+    }
+
+    /**
+     * Checks whether this class has the annotation.
+     *
+     * @param annotation An annotation.
+     * @return true if this class has the annotation.
+     */
+    public boolean hasAnnotation(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return hasAnnotation(annotation.getName());
     }
 
     /**
@@ -1398,6 +1432,17 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
     }
 
     /**
+     * Checks whether this class declares a field with the annotation.
+     *
+     * @param annotation A field annotation.
+     * @return true if this class declares a field with the annotation.
+     */
+    public boolean hasDeclaredFieldAnnotation(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return hasDeclaredFieldAnnotation(annotation.getName());
+    }
+
+    /**
      * Checks whether this class declares a field with the named annotation.
      *
      * @param fieldAnnotationName
@@ -1411,6 +1456,17 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
             }
         }
         return false;
+    }
+
+    /**
+     * Checks whether this class or one of its superclasses declares a field with the annotation.
+     *
+     * @param fieldAnnotation A field annotation.
+     * @return true if this class or one of its superclasses declares a field with the annotation.
+     */
+    public boolean hasFieldAnnotation(final Class<? extends Annotation> fieldAnnotation) {
+        Assert.isAnnotation(fieldAnnotation);
+        return hasFieldAnnotation(fieldAnnotation.getName());
     }
 
     /**
@@ -1457,6 +1513,17 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
     }
 
     /**
+     * Checks whether this class declares a method with the annotation.
+     *
+     * @param methodAnnotation A method annotation.
+     * @return true if this class declares a method with the annotation.
+     */
+    public boolean hasDeclaredMethodAnnotation(final Class<? extends Annotation> methodAnnotation) {
+        Assert.isAnnotation(methodAnnotation);
+        return hasDeclaredMethodAnnotation(methodAnnotation.getName());
+    }
+
+    /**
      * Checks whether this class declares a method with the named annotation.
      *
      * @param methodAnnotationName
@@ -1470,6 +1537,19 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
             }
         }
         return false;
+    }
+
+    /**
+     * Checks whether this class or one of its superclasses or interfaces declares a method with the
+     * annotation.
+     *
+     * @param methodAnnotation A method annotation.
+     * @return true if this class or one of its superclasses or interfaces declares a method with the
+     * annotation.
+     */
+    public boolean hasMethodAnnotation(final Class<? extends Annotation> methodAnnotation) {
+        Assert.isAnnotation(methodAnnotation);
+        return hasMethodAnnotation(methodAnnotation.getName());
     }
 
     /**
@@ -1491,6 +1571,17 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
     }
 
     /**
+     * Checks whether this class declares a method with the annotation.
+     *
+     * @param methodParameterAnnotation A method annotation.
+     * @return true if this class declares a method with the annotation.
+     */
+    public boolean hasDeclaredMethodParameterAnnotation(final Class<? extends Annotation> methodParameterAnnotation) {
+        Assert.isAnnotation(methodParameterAnnotation);
+        return hasDeclaredMethodParameterAnnotation(methodParameterAnnotation.getName());
+    }
+
+    /**
      * Checks whether this class declares a method with the named annotation.
      *
      * @param methodParameterAnnotationName
@@ -1504,6 +1595,17 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
             }
         }
         return false;
+    }
+
+    /**
+     * Checks whether this class or one of its superclasses or interfaces has a method with the annotation.
+     *
+     * @param methodParameterAnnotation A method annotation.
+     * @return true if this class or one of its superclasses or interfaces has a method with the annotation.
+     */
+    public boolean hasMethodParameterAnnotation(final Class<? extends Annotation> methodParameterAnnotation) {
+        Assert.isAnnotation(methodParameterAnnotation);
+        return hasMethodParameterAnnotation(methodParameterAnnotation.getName());
     }
 
     /**
@@ -1837,7 +1939,7 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
     }
 
     /**
-     * Get a the named non-{@link Repeatable} annotation on this class, or null if the class does not have the named
+     * Get a the non-{@link Repeatable} annotation on this class, or null if the class does not have the
      * annotation. (Use {@link #getAnnotationInfoRepeatable(String)} for {@link Repeatable} annotations.)
      * 
      * <p>
@@ -1845,10 +1947,33 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
      * its subclasses.
      * 
      * <p>
+     * Note that if you need to get multiple annotations, it is faster to call {@link #getAnnotationInfo()},
+     * and then get the annotations from the returned {@link AnnotationInfoList}, so that the returned list
+     * doesn't have to be built multiple times.
+     * 
+     * @param annotation
+     *            The annotation.
+     * @return An {@link AnnotationInfo} object representing the annotation on this class, or null if the
+     *         class does not have the annotation.
+     */
+    public AnnotationInfo getAnnotationInfo(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfo(annotation.getName());
+    }
+
+    /**
+     * Get a the named non-{@link Repeatable} annotation on this class, or null if the class does not have the named
+     * annotation. (Use {@link #getAnnotationInfoRepeatable(String)} for {@link Repeatable} annotations.)
+     *
+     * <p>
+     * Also handles the {@link Inherited} meta-annotation, which causes an annotation to annotate a class and all of
+     * its subclasses.
+     *
+     * <p>
      * Note that if you need to get multiple named annotations, it is faster to call {@link #getAnnotationInfo()},
      * and then get the named annotations from the returned {@link AnnotationInfoList}, so that the returned list
      * doesn't have to be built multiple times.
-     * 
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfo} object representing the named annotation on this class, or null if the
@@ -1859,18 +1984,41 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
     }
 
     /**
-     * Get a the named {@link Repeatable} annotation on this class, or the empty list if the class does not have the
-     * named annotation.
+     * Get a the {@link Repeatable} annotation on this class, or the empty list if the class does not have the
+     * annotation.
      * 
      * <p>
      * Also handles the {@link Inherited} meta-annotation, which causes an annotation to annotate a class and all of
      * its subclasses.
      * 
      * <p>
+     * Note that if you need to get multiple annotations, it is faster to call {@link #getAnnotationInfo()},
+     * and then get the annotations from the returned {@link AnnotationInfoList}, so that the returned list
+     * doesn't have to be built multiple times.
+     * 
+     * @param annotation
+     *            The annotation.
+     * @return An {@link AnnotationInfoList} of all instances of the annotation on this class, or the empty
+     *         list if the class does not have the annotation.
+     */
+    public AnnotationInfoList getAnnotationInfoRepeatable(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfoRepeatable(annotation.getName());
+    }
+
+    /**
+     * Get a the named {@link Repeatable} annotation on this class, or the empty list if the class does not have the
+     * named annotation.
+     *
+     * <p>
+     * Also handles the {@link Inherited} meta-annotation, which causes an annotation to annotate a class and all of
+     * its subclasses.
+     *
+     * <p>
      * Note that if you need to get multiple named annotations, it is faster to call {@link #getAnnotationInfo()},
      * and then get the named annotations from the returned {@link AnnotationInfoList}, so that the returned list
      * doesn't have to be built multiple times.
-     * 
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfoList} of all instances of the named annotation on this class, or the empty

--- a/src/main/java/io/github/classgraph/FieldInfo.java
+++ b/src/main/java/io/github/classgraph/FieldInfo.java
@@ -28,6 +28,7 @@
  */
 package io.github.classgraph;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -40,6 +41,7 @@ import io.github.classgraph.Classfile.TypeAnnotationDecorator;
 import nonapi.io.github.classgraph.types.ParseException;
 import nonapi.io.github.classgraph.types.TypeUtils;
 import nonapi.io.github.classgraph.types.TypeUtils.ModifierType;
+import nonapi.io.github.classgraph.utils.Assert;
 import nonapi.io.github.classgraph.utils.LogNode;
 
 /**
@@ -371,9 +373,23 @@ public class FieldInfo extends ScanResultObject implements Comparable<FieldInfo>
     }
 
     /**
+     * Get a the non-{@link Repeatable} annotation on this field, or null if the field does not have the
+     * annotation. (Use {@link #getAnnotationInfoRepeatable(Class)} for {@link Repeatable} annotations.)
+     * 
+     * @param annotation
+     *            The annotation.
+     * @return An {@link AnnotationInfo} object representing the annotation on this field, or null if the
+     *         field does not have the annotation.
+     */
+    public AnnotationInfo getAnnotationInfo(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfo(annotation.getName());
+    }
+
+    /**
      * Get a the named non-{@link Repeatable} annotation on this field, or null if the field does not have the named
      * annotation. (Use {@link #getAnnotationInfoRepeatable(String)} for {@link Repeatable} annotations.)
-     * 
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfo} object representing the named annotation on this field, or null if the
@@ -384,9 +400,23 @@ public class FieldInfo extends ScanResultObject implements Comparable<FieldInfo>
     }
 
     /**
+     * Get a the {@link Repeatable} annotation on this field, or the empty list if the field does not have the
+     * annotation.
+     * 
+     * @param annotation
+     *            The annotation.
+     * @return An {@link AnnotationInfoList} of all instances of the annotation on this field, or the empty
+     *         list if the field does not have the annotation.
+     */
+    public AnnotationInfoList getAnnotationInfoRepeatable(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfoRepeatable(annotation.getName());
+    }
+
+    /**
      * Get a the named {@link Repeatable} annotation on this field, or the empty list if the field does not have the
      * named annotation.
-     * 
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfoList} of all instances of the named annotation on this field, or the empty
@@ -394,6 +424,17 @@ public class FieldInfo extends ScanResultObject implements Comparable<FieldInfo>
      */
     public AnnotationInfoList getAnnotationInfoRepeatable(final String annotationName) {
         return getAnnotationInfo().getRepeatable(annotationName);
+    }
+
+    /**
+     * Check if the field has a given annotation.
+     *
+     * @param annotation The annotation.
+     * @return true if this field has the annotation.
+     */
+    public boolean hasAnnotation(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return hasAnnotation(annotation.getName());
     }
 
     /**

--- a/src/main/java/io/github/classgraph/MethodInfo.java
+++ b/src/main/java/io/github/classgraph/MethodInfo.java
@@ -28,6 +28,7 @@
  */
 package io.github.classgraph;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -42,6 +43,7 @@ import io.github.classgraph.Classfile.MethodTypeAnnotationDecorator;
 import nonapi.io.github.classgraph.types.ParseException;
 import nonapi.io.github.classgraph.types.TypeUtils;
 import nonapi.io.github.classgraph.types.TypeUtils.ModifierType;
+import nonapi.io.github.classgraph.utils.Assert;
 import nonapi.io.github.classgraph.utils.LogNode;
 
 /**
@@ -573,9 +575,22 @@ public class MethodInfo extends ScanResultObject implements Comparable<MethodInf
     }
 
     /**
+     * Get a the non-{@link Repeatable} annotation on this method, or null if the method does not have the
+     * annotation. (Use {@link #getAnnotationInfoRepeatable(Class)} for {@link Repeatable} annotations.)
+     *
+     * @param annotation The annotation.
+     * @return An {@link AnnotationInfo} object representing the annotation on this method, or null if the
+     * method does not have the annotation.
+     */
+    public AnnotationInfo getAnnotationInfo(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfo(annotation.getName());
+    }
+
+    /**
      * Get a the named non-{@link Repeatable} annotation on this method, or null if the method does not have the
      * named annotation. (Use {@link #getAnnotationInfoRepeatable(String)} for {@link Repeatable} annotations.)
-     * 
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfo} object representing the named annotation on this method, or null if the
@@ -586,9 +601,22 @@ public class MethodInfo extends ScanResultObject implements Comparable<MethodInf
     }
 
     /**
+     * Get a the {@link Repeatable} annotation on this method, or the empty list if the method does not have
+     * the annotation.
+     *
+     * @param annotation The annotation.
+     * @return An {@link AnnotationInfoList} containing all instances of the annotation on this method, or the
+     * empty list if the method does not have the annotation.
+     */
+    public AnnotationInfoList getAnnotationInfoRepeatable(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfoRepeatable(annotation.getName());
+    }
+
+    /**
      * Get a the named {@link Repeatable} annotation on this method, or the empty list if the method does not have
      * the named annotation.
-     * 
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfoList} containing all instances of the named annotation on this method, or the
@@ -596,6 +624,17 @@ public class MethodInfo extends ScanResultObject implements Comparable<MethodInf
      */
     public AnnotationInfoList getAnnotationInfoRepeatable(final String annotationName) {
         return getAnnotationInfo().getRepeatable(annotationName);
+    }
+
+    /**
+     * Check if this method has the annotation.
+     *
+     * @param annotation The annotation.
+     * @return true if this method has the annotation.
+     */
+    public boolean hasAnnotation(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return hasAnnotation(annotation.getName());
     }
 
     /**
@@ -607,6 +646,17 @@ public class MethodInfo extends ScanResultObject implements Comparable<MethodInf
      */
     public boolean hasAnnotation(final String annotationName) {
         return getAnnotationInfo().containsName(annotationName);
+    }
+
+    /**
+     * Check if this method has a parameter with the annotation.
+     *
+     * @param annotation The method parameter annotation.
+     * @return true if this method has a parameter with the annotation.
+     */
+    public boolean hasParameterAnnotation(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return hasParameterAnnotation(annotation.getName());
     }
 
     /**

--- a/src/main/java/io/github/classgraph/MethodParameterInfo.java
+++ b/src/main/java/io/github/classgraph/MethodParameterInfo.java
@@ -28,6 +28,9 @@
  */
 package io.github.classgraph;
 
+import nonapi.io.github.classgraph.utils.Assert;
+
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -179,10 +182,25 @@ public class MethodParameterInfo {
     }
 
     /**
+     * Get a the non-{@link Repeatable} annotation on this method, or null if the method parameter does not
+     * have the annotation. (Use {@link #getAnnotationInfoRepeatable(Class)} for {@link Repeatable}
+     * annotations.)
+     * 
+     * @param annotation
+     *            The annotation.
+     * @return An {@link AnnotationInfo} object representing the annotation on this method parameter, or null
+     *         if the method parameter does not have the annotation.
+     */
+    public AnnotationInfo getAnnotationInfo(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfo(annotation.getName());
+    }
+
+    /**
      * Get a the named non-{@link Repeatable} annotation on this method, or null if the method parameter does not
      * have the named annotation. (Use {@link #getAnnotationInfoRepeatable(String)} for {@link Repeatable}
      * annotations.)
-     * 
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfo} object representing the named annotation on this method parameter, or null
@@ -193,9 +211,23 @@ public class MethodParameterInfo {
     }
 
     /**
+     * Get a the {@link Repeatable} annotation on this method, or the empty list if the method parameter does
+     * not have the annotation.
+     * 
+     * @param annotation
+     *            The annotation.
+     * @return An {@link AnnotationInfoList} containing all instances of the annotation on this method
+     *         parameter, or the empty list if the method parameter does not have the annotation.
+     */
+    public AnnotationInfoList getAnnotationInfoRepeatable(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfoRepeatable(annotation.getName());
+    }
+
+    /**
      * Get a the named {@link Repeatable} annotation on this method, or the empty list if the method parameter does
      * not have the named annotation.
-     * 
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfoList} containing all instances of the named annotation on this method
@@ -203,6 +235,17 @@ public class MethodParameterInfo {
      */
     public AnnotationInfoList getAnnotationInfoRepeatable(final String annotationName) {
         return getAnnotationInfo().getRepeatable(annotationName);
+    }
+
+    /**
+     * Check whether this method parameter has the annotation.
+     *
+     * @param annotation The annotation.
+     * @return true if this method parameter has the annotation.
+     */
+    public boolean hasAnnotation(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return hasAnnotation(annotation.getName());
     }
 
     /**

--- a/src/main/java/io/github/classgraph/ModuleInfo.java
+++ b/src/main/java/io/github/classgraph/ModuleInfo.java
@@ -28,11 +28,13 @@
  */
 package io.github.classgraph;
 
+import java.lang.annotation.Annotation;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import nonapi.io.github.classgraph.utils.Assert;
 import nonapi.io.github.classgraph.utils.CollectionUtils;
 
 /** Holds metadata about a package encountered during a scan. */
@@ -232,8 +234,20 @@ public class ModuleInfo implements Comparable<ModuleInfo>, HasName {
     }
 
     /**
+     * Get a the annotation on this module, or null if the module does not have the annotation.
+     *
+     * @param annotation The annotation.
+     * @return An {@link AnnotationInfo} object representing the annotation on this module, or null if the
+     * module does not have the annotation.
+     */
+    public AnnotationInfo getAnnotationInfo(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfo(annotation.getName());
+    }
+
+    /**
      * Get a the named annotation on this module, or null if the module does not have the named annotation.
-     * 
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfo} object representing the named annotation on this module, or null if the
@@ -261,8 +275,19 @@ public class ModuleInfo implements Comparable<ModuleInfo>, HasName {
     }
 
     /**
+     * Check if this module has the annotation.
+     *
+     * @param annotation The annotation.
+     * @return true if this module has the annotation.
+     */
+    public boolean hasAnnotation(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return hasAnnotation(annotation.getName());
+    }
+
+    /**
      * Check if this module has the named annotation.
-     * 
+     *
      * @param annotationName
      *            The name of an annotation.
      * @return true if this module has the named annotation.

--- a/src/main/java/io/github/classgraph/PackageInfo.java
+++ b/src/main/java/io/github/classgraph/PackageInfo.java
@@ -28,6 +28,7 @@
  */
 package io.github.classgraph;
 
+import java.lang.annotation.Annotation;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 import nonapi.io.github.classgraph.scanspec.ScanSpec;
+import nonapi.io.github.classgraph.utils.Assert;
 import nonapi.io.github.classgraph.utils.CollectionUtils;
 
 /** Holds metadata about a package encountered during a scan. */
@@ -123,8 +125,21 @@ public class PackageInfo implements Comparable<PackageInfo>, HasName {
     // -------------------------------------------------------------------------------------------------------------
 
     /**
-     * Get a the named annotation on this package, or null if the package does not have the named annotation.
+     * Get a the annotation on this package, or null if the package does not have the annotation.
      * 
+     * @param annotation
+     *            The annotation.
+     * @return An {@link AnnotationInfo} object representing the annotation on this package, or null if the
+     *         package does not have the annotation.
+     */
+    public AnnotationInfo getAnnotationInfo(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getAnnotationInfo(annotation.getName());
+    }
+
+    /**
+     * Get a the named annotation on this package, or null if the package does not have the named annotation.
+     *
      * @param annotationName
      *            The annotation name.
      * @return An {@link AnnotationInfo} object representing the named annotation on this package, or null if the
@@ -149,6 +164,17 @@ public class PackageInfo implements Comparable<PackageInfo>, HasName {
             }
         }
         return annotationInfo;
+    }
+
+    /**
+     * Check if the package has the annotation.
+     *
+     * @param annotation The annotation.
+     * @return true if this package has the annotation.
+     */
+    public boolean hasAnnotation(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return hasAnnotation(annotation.getName());
     }
 
     /**

--- a/src/main/java/io/github/classgraph/ScanResult.java
+++ b/src/main/java/io/github/classgraph/ScanResult.java
@@ -30,6 +30,7 @@ package io.github.classgraph;
 
 import java.io.Closeable;
 import java.io.File;
+import java.lang.annotation.Annotation;
 import java.lang.ref.WeakReference;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -56,10 +57,7 @@ import nonapi.io.github.classgraph.fastzipfilereader.NestedJarHandler;
 import nonapi.io.github.classgraph.json.JSONDeserializer;
 import nonapi.io.github.classgraph.json.JSONSerializer;
 import nonapi.io.github.classgraph.scanspec.ScanSpec;
-import nonapi.io.github.classgraph.utils.CollectionUtils;
-import nonapi.io.github.classgraph.utils.FileUtils;
-import nonapi.io.github.classgraph.utils.JarUtils;
-import nonapi.io.github.classgraph.utils.LogNode;
+import nonapi.io.github.classgraph.utils.*;
 
 /**
  * The result of a scan. You should assign a ScanResult in a try-with-resources block, or manually close it when you
@@ -883,6 +881,16 @@ public final class ScanResult implements Closeable, AutoCloseable {
     }
 
     /**
+     * Get all subclasses of the superclass.
+     *
+     * @param superclass The superclass.
+     * @return A list of subclasses of the superclass, or the empty list if none.
+     */
+    public ClassInfoList getSubclasses(final Class<?> superclass) {
+        return getSubclasses(superclass.getName());
+    }
+
+    /**
      * Get all subclasses of the named superclass.
      *
      * @param superclassName
@@ -926,6 +934,17 @@ public final class ScanResult implements Closeable, AutoCloseable {
     /**
      * Get classes that have a method with an annotation of the named type.
      *
+     * @param methodAnnotation the method annotation.
+     * @return A list of classes with a method that has an annotation of the named type, or the empty list if none.
+     */
+    public ClassInfoList getClassesWithMethodAnnotation(final Class<? extends Annotation> methodAnnotation) {
+        Assert.isAnnotation(methodAnnotation);
+        return getClassesWithMethodAnnotation(methodAnnotation.getName());
+    }
+
+    /**
+     * Get classes that have a method with an annotation of the named type.
+     *
      * @param methodAnnotationName
      *            the name of the method annotation.
      * @return A list of classes with a method that has an annotation of the named type, or the empty list if none.
@@ -940,6 +959,18 @@ public final class ScanResult implements Closeable, AutoCloseable {
         }
         final ClassInfo classInfo = classNameToClassInfo.get(methodAnnotationName);
         return classInfo == null ? ClassInfoList.EMPTY_LIST : classInfo.getClassesWithMethodAnnotation();
+    }
+
+    /**
+     * Get classes that have a method with a parameter that is annotated with an annotation of the named type.
+     *
+     * @param methodParameterAnnotation the method parameter annotation.
+     * @return A list of classes that have a method with a parameter annotated with the named annotation type, or
+     * the empty list if none.
+     */
+    public ClassInfoList getClassesWithMethodParameterAnnotation(final Class<? extends Annotation> methodParameterAnnotation) {
+        Assert.isAnnotation(methodParameterAnnotation);
+        return getClassesWithMethodParameterAnnotation(methodParameterAnnotation.getName());
     }
 
     /**
@@ -960,6 +991,17 @@ public final class ScanResult implements Closeable, AutoCloseable {
         }
         final ClassInfo classInfo = classNameToClassInfo.get(methodParameterAnnotationName);
         return classInfo == null ? ClassInfoList.EMPTY_LIST : classInfo.getClassesWithMethodParameterAnnotation();
+    }
+
+    /**
+     * Get classes that have a field with an annotation of the named type.
+     *
+     * @param fieldAnnotation the field annotation.
+     * @return A list of classes that have a field with an annotation of the named type, or the empty list if none.
+     */
+    public ClassInfoList getClassesWithFieldAnnotation(final Class<? extends Annotation> fieldAnnotation) {
+        Assert.isAnnotation(fieldAnnotation);
+        return getClassesWithFieldAnnotation(fieldAnnotation.getName());
     }
 
     /**
@@ -1021,6 +1063,18 @@ public final class ScanResult implements Closeable, AutoCloseable {
     }
 
     /**
+     * Get all classes that implement (or have superclasses that implement) the interface (or one of its
+     * subinterfaces).
+     *
+     * @param interfaceClass The interface class.
+     * @return A list of all classes that implement the interface, or the empty list if none.
+     */
+    public ClassInfoList getClassesImplementing(final Class<?> interfaceClass) {
+        Assert.isInterface(interfaceClass);
+        return getClassesImplementing(interfaceClass.getName());
+    }
+
+    /**
      * Get all classes that implement (or have superclasses that implement) the named interface (or one of its
      * subinterfaces).
      *
@@ -1073,6 +1127,18 @@ public final class ScanResult implements Closeable, AutoCloseable {
                     "Please call ClassGraph#enableClassInfo() and #enableAnnotationInfo() before #scan()");
         }
         return ClassInfo.getAllInterfacesOrAnnotationClasses(classNameToClassInfo.values(), scanSpec);
+    }
+
+    /**
+     * Get classes with the class annotation or meta-annotation.
+     *
+     * @param annotation The class annotation or meta-annotation.
+     * @return A list of all non-annotation classes that were found with the class annotation during the scan,
+     * or the empty list if none.
+     */
+    public ClassInfoList getClassesWithAnnotation(final Class<? extends Annotation> annotation) {
+        Assert.isAnnotation(annotation);
+        return getClassesWithAnnotation(annotation.getName());
     }
 
     /**

--- a/src/main/java/nonapi/io/github/classgraph/utils/Assert.java
+++ b/src/main/java/nonapi/io/github/classgraph/utils/Assert.java
@@ -1,0 +1,16 @@
+package nonapi.io.github.classgraph.utils;
+
+public final class Assert {
+
+    public static void isAnnotation(Class<?> clazz) {
+        if (!clazz.isAnnotation()) {
+            throw new IllegalArgumentException(clazz + " is not an annotation");
+        }
+    }
+
+    public static void isInterface(Class<?> clazz) {
+        if (!clazz.isInterface()) {
+            throw new IllegalArgumentException(clazz + " is not an interface");
+        }
+    }
+}

--- a/src/test/java/io/github/classgraph/features/MethodParameterAnnotationsTest.java
+++ b/src/test/java/io/github/classgraph/features/MethodParameterAnnotationsTest.java
@@ -68,9 +68,9 @@ public class MethodParameterAnnotationsTest {
                     .containsOnly(W.class.getName());
             assertThat(scanResult.getClassInfo(Z.class.getName()).getMethodParameterAnnotations().getNames())
                     .containsOnly(X.class.getName());
-            assertThat(scanResult.getClassesWithMethodParameterAnnotation(W.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithMethodParameterAnnotation(W.class).getNames())
                     .containsOnly(Y.class.getName());
-            assertThat(scanResult.getClassesWithMethodParameterAnnotation(X.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithMethodParameterAnnotation(X.class).getNames())
                     .containsOnly(Z.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/issues/IssuesTest.java
+++ b/src/test/java/io/github/classgraph/issues/IssuesTest.java
@@ -21,7 +21,7 @@ public class IssuesTest {
     @Test
     public void issue70() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(Impl1.class.getPackage().getName()).scan()) {
-            assertThat(scanResult.getSubclasses(Object.class.getName()).getNames()).contains(Impl1.class.getName());
+            assertThat(scanResult.getSubclasses(Object.class).getNames()).contains(Impl1.class.getName());
         }
     }
 
@@ -32,7 +32,7 @@ public class IssuesTest {
     public void issue70EnableExternalClasses() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(Impl1.class.getPackage().getName())
                 .enableExternalClasses().scan()) {
-            assertThat(scanResult.getSubclasses(Object.class.getName()).getNames()).contains(Impl1.class.getName());
+            assertThat(scanResult.getSubclasses(Object.class).getNames()).contains(Impl1.class.getName());
             assertThat(scanResult.getSuperclasses(Impl1Sub.class.getName()).getNames())
                     .containsOnly(Impl1.class.getName());
         }
@@ -70,7 +70,7 @@ public class IssuesTest {
     public void extendsExternalSubclass() {
         try (ScanResult scanResult = new ClassGraph()
                 .acceptPackages(InternalExtendsExternal.class.getPackage().getName()).scan()) {
-            assertThat(scanResult.getSubclasses(ExternalSuperclass.class.getName()).getNames())
+            assertThat(scanResult.getSubclasses(ExternalSuperclass.class).getNames())
                     .containsOnly(InternalExtendsExternal.class.getName());
         }
     }
@@ -83,7 +83,7 @@ public class IssuesTest {
         try (ScanResult scanResult = new ClassGraph()
                 .acceptPackages(InternalExtendsExternal.class.getPackage().getName()).enableExternalClasses()
                 .scan()) {
-            assertThat(scanResult.getSubclasses(ExternalSuperclass.class.getName()).getNames())
+            assertThat(scanResult.getSubclasses(ExternalSuperclass.class).getNames())
                     .containsOnly(InternalExtendsExternal.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/issues/issue101/Issue101Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue101/Issue101Test.java
@@ -46,7 +46,7 @@ public class Issue101Test {
     public void nonInheritedAnnotation() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(Issue101Test.class.getPackage().getName())
                 .enableAllInfo().scan()) {
-            assertThat(scanResult.getClassesWithAnnotation(NonInheritedAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(NonInheritedAnnotation.class).getNames())
                     .containsOnly(AnnotatedClass.class.getName());
         }
     }
@@ -58,7 +58,7 @@ public class Issue101Test {
     public void inheritedMetaAnnotation() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(Issue101Test.class.getPackage().getName())
                 .enableAllInfo().scan()) {
-            assertThat(scanResult.getClassesWithAnnotation(InheritedMetaAnnotation.class.getName())
+            assertThat(scanResult.getClassesWithAnnotation(InheritedMetaAnnotation.class)
                     .getStandardClasses().getNames()).containsOnly(AnnotatedClass.class.getName(),
                             NonAnnotatedSubclass.class.getName());
         }
@@ -71,7 +71,7 @@ public class Issue101Test {
     public void inheritedAnnotation() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(Issue101Test.class.getPackage().getName())
                 .enableAllInfo().scan()) {
-            assertThat(scanResult.getClassesWithAnnotation(InheritedAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(InheritedAnnotation.class).getNames())
                     .containsOnly(AnnotatedClass.class.getName(), NonAnnotatedSubclass.class.getName(),
                             AnnotatedInterface.class.getName());
         }

--- a/src/test/java/io/github/classgraph/issues/issue107/Issue107Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue107/Issue107Test.java
@@ -51,7 +51,7 @@ public class Issue107Test {
                 // package-info is a non-public class
                 .ignoreClassVisibility() //
                 .scan()) {
-            assertThat(scanResult.getClassesWithAnnotation(PackageAnnotation.class.getName()).getNames()).isEmpty();
+            assertThat(scanResult.getClassesWithAnnotation(PackageAnnotation.class).getNames()).isEmpty();
             assertThat(scanResult.getPackageInfo().getNames())
                     .containsAll(Arrays.asList("io.github.classgraph", Issue107Test.class.getPackage().getName()));
             assertThat(scanResult.getPackageInfo(Issue107Test.class.getPackage().getName()).getAnnotationInfo()

--- a/src/test/java/io/github/classgraph/issues/issue216/Issue216Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue216/Issue216Test.java
@@ -54,7 +54,7 @@ public class Issue216Test {
             assertThat(result.getAllClasses().filter(new ClassInfoFilter() {
                 @Override
                 public boolean accept(final ClassInfo ci) {
-                    return ci.hasAnnotation(Entity.class.getName());
+                    return ci.hasAnnotation(Entity.class);
                 }
             }).getNames()).containsOnly(Issue216Test.class.getName());
         }

--- a/src/test/java/io/github/classgraph/issues/issue261/Issue261Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue261/Issue261Test.java
@@ -64,7 +64,7 @@ public class Issue261Test {
     public void issue261Test() {
         // Accept only the class Cls, so that SuperCls and SuperSuperCls are external classes
         try (ScanResult scanResult = new ClassGraph().acceptClasses(Cls.class.getName()).enableAllInfo().scan()) {
-            assertThat(scanResult.getSubclasses(SuperSuperCls.class.getName()).getNames())
+            assertThat(scanResult.getSubclasses(SuperSuperCls.class).getNames())
                     .containsOnly(SuperCls.class.getName(), Cls.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/issues/issue314/Issue314.java
+++ b/src/test/java/io/github/classgraph/issues/issue314/Issue314.java
@@ -44,8 +44,8 @@ public class Issue314 {
             try (final ScanResult scanResult2 = ScanResult.fromJSON(scanResult1.toJSON())) {
                 final String json2 = scanResult2.toJSON(2);
                 assertThat(json1).isEqualTo(json2);
-                assertThat(scanResult1.getSubclasses(A.class.getName()).getNames()).containsOnly(B.class.getName());
-                assertThat(scanResult2.getSubclasses(A.class.getName()).getNames()).containsOnly(B.class.getName());
+                assertThat(scanResult1.getSubclasses(A.class).getNames()).containsOnly(B.class.getName());
+                assertThat(scanResult2.getSubclasses(A.class).getNames()).containsOnly(B.class.getName());
             }
         }
     }

--- a/src/test/java/io/github/classgraph/issues/issue318/Issue318.java
+++ b/src/test/java/io/github/classgraph/issues/issue318/Issue318.java
@@ -82,7 +82,7 @@ public class Issue318 {
             assertThat(scanResult.getClassesWithAnnotation(MyAnn.class).getNames()).containsOnly(
                     With1MyAnn.class.getName(), With2MyAnn.class.getName(), With3MyAnn.class.getName());
             assertThat(scanResult.getClassInfo(With3MyAnn.class.getName())
-                    .getAnnotationInfoRepeatable(MyAnn.class.getName()).size()).isEqualTo(3);
+                    .getAnnotationInfoRepeatable(MyAnn.class).size()).isEqualTo(3);
         }
     }
 }

--- a/src/test/java/io/github/classgraph/issues/issue318/Issue318.java
+++ b/src/test/java/io/github/classgraph/issues/issue318/Issue318.java
@@ -79,7 +79,7 @@ public class Issue318 {
                 .enableAnnotationInfo().enableClassInfo().ignoreClassVisibility() //
                 //.verbose() //
                 .scan()) {
-            assertThat(scanResult.getClassesWithAnnotation(MyAnn.class.getName()).getNames()).containsOnly(
+            assertThat(scanResult.getClassesWithAnnotation(MyAnn.class).getNames()).containsOnly(
                     With1MyAnn.class.getName(), With2MyAnn.class.getName(), With3MyAnn.class.getName());
             assertThat(scanResult.getClassInfo(With3MyAnn.class.getName())
                     .getAnnotationInfoRepeatable(MyAnn.class.getName()).size()).isEqualTo(3);

--- a/src/test/java/io/github/classgraph/issues/issue350/Issue350.java
+++ b/src/test/java/io/github/classgraph/issues/issue350/Issue350.java
@@ -70,17 +70,17 @@ public class Issue350 {
     public void test() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(Issue350.class.getPackage().getName())
                 .enableClassInfo().enableFieldInfo().enableMethodInfo().enableAnnotationInfo().scan()) {
-            assertThat(scanResult.getClassesWithFieldAnnotation(SuperclassAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithFieldAnnotation(SuperclassAnnotation.class).getNames())
                     .containsOnly(Pub.class.getName(), PubSub.class.getName());
-            assertThat(scanResult.getClassesWithMethodAnnotation(SuperclassAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithMethodAnnotation(SuperclassAnnotation.class).getNames())
                     .containsOnly(Pub.class.getName(), PubSub.class.getName());
         }
         try (ScanResult scanResult = new ClassGraph().acceptPackages(Issue350.class.getPackage().getName())
                 .enableClassInfo().enableFieldInfo().enableMethodInfo().enableAnnotationInfo()
                 .ignoreFieldVisibility().ignoreMethodVisibility().scan()) {
-            assertThat(scanResult.getClassesWithFieldAnnotation(SuperclassAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithFieldAnnotation(SuperclassAnnotation.class).getNames())
                     .containsOnly(Pub.class.getName(), PubSub.class.getName(), Priv.class.getName());
-            assertThat(scanResult.getClassesWithMethodAnnotation(SuperclassAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithMethodAnnotation(SuperclassAnnotation.class).getNames())
                     .containsOnly(Pub.class.getName(), PubSub.class.getName(), Priv.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/issues/issue370/Issue370Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue370/Issue370Test.java
@@ -54,7 +54,7 @@ public class Issue370Test {
             final ClassInfo clazzInfo = scanResult.getClassInfo(ClassWithAnnotation.class.getName());
             assertThat(clazzInfo).isNotNull();
             for (final MethodInfo methodInfo : clazzInfo.getMethodInfo().filter(MethodInfo::isPublic)) {
-                final AnnotationInfo annotationInfo = methodInfo.getAnnotationInfo(ApiOperation.class.getName());
+                final AnnotationInfo annotationInfo = methodInfo.getAnnotationInfo(ApiOperation.class);
                 final String value = annotationInfo.getParameterValues().get("notes").getValue().toString();
                 assertThat(value).isEqualTo("${snippetclassifications.findById}");
             }

--- a/src/test/java/io/github/classgraph/issues/issue38/Issue38Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue38/Issue38Test.java
@@ -29,7 +29,7 @@ class Issue38Test {
     void testImplementsSuppressWarnings() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(Issue38Test.class.getPackage().getName())
                 .scan()) {
-            assertThat(scanResult.getClassesImplementing(SuppressWarnings.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(SuppressWarnings.class).getNames())
                     .containsOnly(ImplementsSuppressWarnings.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/issues/issue74/Issue74Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue74/Issue74Test.java
@@ -42,7 +42,7 @@ public class Issue74Test {
     public void issue74() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(Issue74Test.class.getPackage().getName())
                 .scan()) {
-            assertThat(scanResult.getClassesImplementing(Function.class.getName()).getNames()).containsOnly(
+            assertThat(scanResult.getClassesImplementing(Function.class).getNames()).containsOnly(
                     FunctionAdapter.class.getName(), ImplementsFunction.class.getName(),
                     ExtendsFunctionAdapter.class.getName());
         }

--- a/src/test/java/io/github/classgraph/issues/issue93/Issue93.java
+++ b/src/test/java/io/github/classgraph/issues/issue93/Issue93.java
@@ -50,9 +50,9 @@ public class Issue93 {
     public void classRetentionIsDefault() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(PKG).enableAnnotationInfo()
                 .ignoreClassVisibility().scan()) {
-            assertThat(scanResult.getClassesWithAnnotation(RetentionClass.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(RetentionClass.class).getNames())
                     .containsOnly(RetentionClassAnnotated.class.getName());
-            assertThat(scanResult.getClassesWithAnnotation(RetentionRuntime.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(RetentionRuntime.class).getNames())
                     .containsOnly(RetentionRuntimeAnnotated.class.getName());
         }
     }
@@ -65,8 +65,8 @@ public class Issue93 {
     public void classRetentionIsNotVisibleWithRetentionPolicyRUNTIME() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(PKG).enableAnnotationInfo()
                 .ignoreClassVisibility().disableRuntimeInvisibleAnnotations().scan()) {
-            assertThat(scanResult.getClassesWithAnnotation(RetentionClass.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getClassesWithAnnotation(RetentionRuntime.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(RetentionClass.class).getNames()).isEmpty();
+            assertThat(scanResult.getClassesWithAnnotation(RetentionRuntime.class).getNames())
                     .containsOnly(RetentionRuntimeAnnotated.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/test/ClassGraphTest.java
+++ b/src/test/java/io/github/classgraph/test/ClassGraphTest.java
@@ -125,7 +125,7 @@ public class ClassGraphTest {
     @Test
     public void scanSubAndSuperclasses() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(ACCEPT_PACKAGE).scan()) {
-            final List<String> subclasses = scanResult.getSubclasses(Cls.class.getName()).getNames();
+            final List<String> subclasses = scanResult.getSubclasses(Cls.class).getNames();
             assertThat(subclasses).doesNotContain(Cls.class.getName());
             assertThat(subclasses).contains(ClsSub.class.getName());
             assertThat(subclasses).contains(ClsSubSub.class.getName());
@@ -142,7 +142,7 @@ public class ClassGraphTest {
     @Test
     public void scanSubAndSuperinterface() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(ACCEPT_PACKAGE).scan()) {
-            final List<String> subinterfaces = scanResult.getClassesImplementing(Iface.class.getName()).getNames();
+            final List<String> subinterfaces = scanResult.getClassesImplementing(Iface.class).getNames();
             assertThat(subinterfaces).doesNotContain(Iface.class.getName());
             assertThat(subinterfaces).contains(IfaceSub.class.getName());
             assertThat(subinterfaces).contains(IfaceSubSub.class.getName());
@@ -159,47 +159,47 @@ public class ClassGraphTest {
     @Test
     public void scanTransitiveImplements() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(ACCEPT_PACKAGE).scan()) {
-            assertThat(scanResult.getClassesImplementing(Iface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(Iface.class).getNames())
                     .doesNotContain(Iface.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class).getNames())
                     .doesNotContain(Cls.class.getName());
 
-            assertThat(scanResult.getClassesImplementing(Iface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(Iface.class).getNames())
                     .contains(Impl1.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSub.class).getNames())
                     .contains(Impl1.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class).getNames())
                     .contains(Impl1.class.getName());
-            assertThat(scanResult.getClassesImplementing(Iface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(Iface.class).getNames())
                     .contains(Impl1Sub.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSub.class).getNames())
                     .contains(Impl1Sub.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class).getNames())
                     .contains(Impl1Sub.class.getName());
-            assertThat(scanResult.getClassesImplementing(Iface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(Iface.class).getNames())
                     .contains(Impl1SubSub.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSub.class).getNames())
                     .contains(Impl1SubSub.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class).getNames())
                     .contains(Impl1SubSub.class.getName());
 
-            assertThat(scanResult.getClassesImplementing(Iface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(Iface.class).getNames())
                     .contains(Impl2.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSub.class).getNames())
                     .doesNotContain(Impl2.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class).getNames())
                     .doesNotContain(Impl2.class.getName());
-            assertThat(scanResult.getClassesImplementing(Iface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(Iface.class).getNames())
                     .contains(Impl2Sub.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSub.class).getNames())
                     .doesNotContain(Impl2Sub.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class).getNames())
                     .doesNotContain(Impl2Sub.class.getName());
-            assertThat(scanResult.getClassesImplementing(Iface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(Iface.class).getNames())
                     .contains(Impl2SubSub.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSub.class).getNames())
                     .contains(Impl2SubSub.class.getName());
-            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(IfaceSubSub.class).getNames())
                     .contains(Impl2SubSub.class.getName());
         }
     }
@@ -212,9 +212,9 @@ public class ClassGraphTest {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(ACCEPT_PACKAGE).scan()) {
             assertThat(scanResult.getSuperclasses(Accepted.class.getName()).getNames())
                     .containsExactly(RejectedSuperclass.class.getName());
-            assertThat(scanResult.getSubclasses(Accepted.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames()).isEmpty();
+            assertThat(scanResult.getSubclasses(Accepted.class).getNames()).isEmpty();
+            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class).getNames()).isEmpty();
+            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class).getNames()).isEmpty();
         }
     }
 
@@ -249,9 +249,9 @@ public class ClassGraphTest {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(ROOT_PACKAGE)
                 .rejectPackages(RejectedAnnotation.class.getPackage().getName()).enableAnnotationInfo().scan()) {
             assertThat(scanResult.getSuperclasses(Accepted.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getSubclasses(Accepted.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames()).isEmpty();
+            assertThat(scanResult.getSubclasses(Accepted.class).getNames()).isEmpty();
+            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class).getNames()).isEmpty();
+            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class).getNames()).isEmpty();
             assertThat(scanResult.getAnnotationsOnClass(AcceptedInterface.class.getName()).getNames()).isEmpty();
         }
     }
@@ -299,9 +299,9 @@ public class ClassGraphTest {
         try (ScanResult scanResult = new ClassGraph()
                 .acceptPackages(ROOT_PACKAGE, "-" + RejectedSuperclass.class.getPackage().getName()).scan()) {
             assertThat(scanResult.getSuperclasses(Accepted.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getSubclasses(Accepted.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames()).isEmpty();
+            assertThat(scanResult.getSubclasses(Accepted.class).getNames()).isEmpty();
+            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class).getNames()).isEmpty();
+            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class).getNames()).isEmpty();
             assertThat(scanResult.getClassesWithAnnotation(RejectedAnnotation.class).getNames())
                     .isEmpty();
         }
@@ -337,11 +337,11 @@ public class ClassGraphTest {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(ROOT_PACKAGE).enableAnnotationInfo().scan()) {
             assertThat(scanResult.getSuperclasses(Accepted.class.getName()).getNames())
                     .containsExactly(RejectedSuperclass.class.getName());
-            assertThat(scanResult.getSubclasses(Accepted.class.getName()).getNames())
+            assertThat(scanResult.getSubclasses(Accepted.class).getNames())
                     .containsExactly(RejectedSubclass.class.getName());
-            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class).getNames())
                     .containsExactly(RejectedSubinterface.class.getName());
-            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(AcceptedInterface.class).getNames())
                     .containsExactly(RejectedSubinterface.class.getName());
             assertThat(scanResult.getClassesWithAnnotation(RejectedAnnotation.class).getNames())
                     .containsExactly(Accepted.class.getName());

--- a/src/test/java/io/github/classgraph/test/ClassGraphTest.java
+++ b/src/test/java/io/github/classgraph/test/ClassGraphTest.java
@@ -236,7 +236,7 @@ public class ClassGraphTest {
     public void testCanQueryWithRejectedAnnotation() {
         try (ScanResult scanResult = new ClassGraph().acceptPackages(ACCEPT_PACKAGE).scan()) {
             assertThat(scanResult.getSuperclasses(Accepted.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getClassesWithAnnotation(RejectedAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(RejectedAnnotation.class).getNames())
                     .containsExactly(Accepted.class.getName());
         }
     }
@@ -302,7 +302,7 @@ public class ClassGraphTest {
             assertThat(scanResult.getSubclasses(Accepted.class.getName()).getNames()).isEmpty();
             assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames()).isEmpty();
             assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames()).isEmpty();
-            assertThat(scanResult.getClassesWithAnnotation(RejectedAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(RejectedAnnotation.class).getNames())
                     .isEmpty();
         }
     }
@@ -343,7 +343,7 @@ public class ClassGraphTest {
                     .containsExactly(RejectedSubinterface.class.getName());
             assertThat(scanResult.getClassesImplementing(AcceptedInterface.class.getName()).getNames())
                     .containsExactly(RejectedSubinterface.class.getName());
-            assertThat(scanResult.getClassesWithAnnotation(RejectedAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(RejectedAnnotation.class).getNames())
                     .containsExactly(Accepted.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/test/ClassInfoTest.java
+++ b/src/test/java/io/github/classgraph/test/ClassInfoTest.java
@@ -104,7 +104,7 @@ public class ClassInfoTest {
      */
     @Test
     public void implementsInterfaceDirect() {
-        assertThat(scanResult.getClassesImplementing(Iface.class.getName()).directOnly().getNames())
+        assertThat(scanResult.getClassesImplementing(Iface.class).directOnly().getNames())
                 .containsOnly(IfaceSub.class.getName(), Impl2.class.getName());
     }
 
@@ -113,7 +113,7 @@ public class ClassInfoTest {
      */
     @Test
     public void implementsInterface() {
-        assertThat(scanResult.getClassesImplementing(Iface.class.getName()).getNames()).containsOnly(
+        assertThat(scanResult.getClassesImplementing(Iface.class).getNames()).containsOnly(
                 Impl1.class.getName(), Impl1Sub.class.getName(), Impl1SubSub.class.getName(), Impl2.class.getName(),
                 Impl2Sub.class.getName(), Impl2SubSub.class.getName(), IfaceSub.class.getName(),
                 IfaceSubSub.class.getName());

--- a/src/test/java/io/github/classgraph/test/classrefannotation/AnnotationClassRefTest.java
+++ b/src/test/java/io/github/classgraph/test/classrefannotation/AnnotationClassRefTest.java
@@ -86,7 +86,7 @@ public class AnnotationClassRefTest {
                 .acceptPackages(AnnotationClassRefTest.class.getPackage().getName()).enableMethodInfo()
                 .enableAnnotationInfo().scan()) {
             final ClassInfoList testClasses = scanResult
-                    .getClassesWithMethodAnnotation(ClassRefAnnotation.class.getName());
+                    .getClassesWithMethodAnnotation(ClassRefAnnotation.class);
             assertThat(testClasses.size()).isEqualTo(1);
             final ClassInfo testClass = testClasses.get(0);
             final MethodInfo method = testClass.getMethodInfo().getSingleMethod("methodWithAnnotation");

--- a/src/test/java/io/github/classgraph/test/fieldannotation/FieldAndMethodAnnotationTest.java
+++ b/src/test/java/io/github/classgraph/test/fieldannotation/FieldAndMethodAnnotationTest.java
@@ -61,7 +61,7 @@ public class FieldAndMethodAnnotationTest {
                 .acceptPackages(FieldAndMethodAnnotationTest.class.getPackage().getName()).enableFieldInfo()
                 .enableAnnotationInfo().scan()) {
             final List<String> testClasses = scanResult
-                    .getClassesWithFieldAnnotation(ExternalAnnotation.class.getName()).getNames();
+                    .getClassesWithFieldAnnotation(ExternalAnnotation.class).getNames();
             assertThat(testClasses).isEmpty();
         }
     }
@@ -75,7 +75,7 @@ public class FieldAndMethodAnnotationTest {
                 .acceptPackages(FieldAndMethodAnnotationTest.class.getPackage().getName()).enableFieldInfo()
                 .ignoreFieldVisibility().enableAnnotationInfo().scan()) {
             final List<String> testClasses = scanResult
-                    .getClassesWithFieldAnnotation(ExternalAnnotation.class.getName()).getNames();
+                    .getClassesWithFieldAnnotation(ExternalAnnotation.class).getNames();
             assertThat(testClasses).containsOnly(FieldAndMethodAnnotationTest.class.getName());
         }
     }
@@ -90,7 +90,7 @@ public class FieldAndMethodAnnotationTest {
                 .acceptPackages(FieldAndMethodAnnotationTest.class.getPackage().getName()).enableMethodInfo()
                 .enableAnnotationInfo().scan()) {
             final List<String> testClasses = scanResult
-                    .getClassesWithMethodAnnotation(ExternalAnnotation.class.getName()).getNames();
+                    .getClassesWithMethodAnnotation(ExternalAnnotation.class).getNames();
             assertThat(testClasses).containsOnly(FieldAndMethodAnnotationTest.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/test/internal/InternalExternalTest.java
+++ b/src/test/java/io/github/classgraph/test/internal/InternalExternalTest.java
@@ -61,7 +61,7 @@ public class InternalExternalTest {
             assertThat(scanResult.getClassesImplementing(ExternalInterface.class.getName()).getNames())
                     .containsOnly(InternalImplementsExternal.class.getName());
             assertThat(scanResult.getAllAnnotations().getNames()).isEmpty();
-            assertThat(scanResult.getClassesWithAnnotation(ExternalAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(ExternalAnnotation.class).getNames())
                     .containsOnly(InternalAnnotatedByExternal.class.getName());
         }
     }
@@ -82,7 +82,7 @@ public class InternalExternalTest {
                     .containsOnly(InternalImplementsExternal.class.getName());
             assertThat(scanResult.getAllAnnotations().getNames())
                     .doesNotContain(ExternalAnnotation.class.getName());
-            assertThat(scanResult.getClassesWithAnnotation(ExternalAnnotation.class.getName()).getNames())
+            assertThat(scanResult.getClassesWithAnnotation(ExternalAnnotation.class).getNames())
                     .containsOnly(InternalAnnotatedByExternal.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/test/internal/InternalExternalTest.java
+++ b/src/test/java/io/github/classgraph/test/internal/InternalExternalTest.java
@@ -55,10 +55,10 @@ public class InternalExternalTest {
             assertThat(scanResult.getAllStandardClasses().getNames()).containsOnly(
                     InternalExternalTest.class.getName(), InternalExtendsExternal.class.getName(),
                     InternalImplementsExternal.class.getName(), InternalAnnotatedByExternal.class.getName());
-            assertThat(scanResult.getSubclasses(ExternalSuperclass.class.getName()).getNames())
+            assertThat(scanResult.getSubclasses(ExternalSuperclass.class).getNames())
                     .containsOnly(InternalExtendsExternal.class.getName());
             assertThat(scanResult.getAllInterfaces()).isEmpty();
-            assertThat(scanResult.getClassesImplementing(ExternalInterface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(ExternalInterface.class).getNames())
                     .containsOnly(InternalImplementsExternal.class.getName());
             assertThat(scanResult.getAllAnnotations().getNames()).isEmpty();
             assertThat(scanResult.getClassesWithAnnotation(ExternalAnnotation.class).getNames())
@@ -75,10 +75,10 @@ public class InternalExternalTest {
                 .acceptPackages(InternalExternalTest.class.getPackage().getName()).enableAllInfo().scan()) {
             assertThat(scanResult.getAllStandardClasses().getNames())
                     .doesNotContain(ExternalSuperclass.class.getName());
-            assertThat(scanResult.getSubclasses(ExternalSuperclass.class.getName()).getNames())
+            assertThat(scanResult.getSubclasses(ExternalSuperclass.class).getNames())
                     .containsOnly(InternalExtendsExternal.class.getName());
             assertThat(scanResult.getAllInterfaces().getNames()).doesNotContain(ExternalInterface.class.getName());
-            assertThat(scanResult.getClassesImplementing(ExternalInterface.class.getName()).getNames())
+            assertThat(scanResult.getClassesImplementing(ExternalInterface.class).getNames())
                     .containsOnly(InternalImplementsExternal.class.getName());
             assertThat(scanResult.getAllAnnotations().getNames())
                     .doesNotContain(ExternalAnnotation.class.getName());

--- a/src/test/java/io/github/classgraph/test/methodannotation/MethodAnnotationTest.java
+++ b/src/test/java/io/github/classgraph/test/methodannotation/MethodAnnotationTest.java
@@ -54,7 +54,7 @@ public class MethodAnnotationTest {
                 .acceptPackages(MethodAnnotationTest.class.getPackage().getName()).enableClassInfo()
                 .enableMethodInfo().enableAnnotationInfo().scan()) {
             final List<String> testClasses = scanResult
-                    .getClassesWithMethodAnnotation(ExternalAnnotation.class.getName()).getNames();
+                    .getClassesWithMethodAnnotation(ExternalAnnotation.class).getNames();
             assertThat(testClasses).isEmpty();
         }
     }
@@ -68,7 +68,7 @@ public class MethodAnnotationTest {
                 .acceptPackages(MethodAnnotationTest.class.getPackage().getName()).enableClassInfo()
                 .enableMethodInfo().enableAnnotationInfo().ignoreMethodVisibility().scan()) {
             final ClassInfoList classesWithMethodAnnotation = scanResult
-                    .getClassesWithMethodAnnotation(ExternalAnnotation.class.getName());
+                    .getClassesWithMethodAnnotation(ExternalAnnotation.class);
             final List<String> testClasses = classesWithMethodAnnotation.getNames();
             assertThat(testClasses).containsOnly(MethodAnnotationTest.class.getName());
             boolean found = false;

--- a/src/test/java/io/github/classgraph/test/methodannotation2/TestMethodMetaAnnotation.java
+++ b/src/test/java/io/github/classgraph/test/methodannotation2/TestMethodMetaAnnotation.java
@@ -107,7 +107,7 @@ public class TestMethodMetaAnnotation {
         try (ScanResult scanResult = new ClassGraph()
                 .acceptPackages(TestMethodMetaAnnotation.class.getPackage().getName()).enableAnnotationInfo()
                 .scan()) {
-            final List<String> testClasses = scanResult.getClassesWithAnnotation(MetaAnnotation.class.getName())
+            final List<String> testClasses = scanResult.getClassesWithAnnotation(MetaAnnotation.class)
                     .getNames();
             assertThat(testClasses).containsOnly(MethodAnnotation.class.getName(), ClassAnnotation.class.getName(),
                     MetaAnnotatedClass.class.getName());
@@ -123,7 +123,7 @@ public class TestMethodMetaAnnotation {
         try (ScanResult scanResult = new ClassGraph()
                 .acceptPackages(TestMethodMetaAnnotation.class.getPackage().getName()).enableAnnotationInfo()
                 .scan()) {
-            final List<String> testClasses = scanResult.getClassesWithAnnotation(MetaAnnotation.class.getName())
+            final List<String> testClasses = scanResult.getClassesWithAnnotation(MetaAnnotation.class)
                     .getStandardClasses().getNames();
             assertThat(testClasses).containsOnly(MetaAnnotatedClass.class.getName());
         }
@@ -139,7 +139,7 @@ public class TestMethodMetaAnnotation {
                 .acceptPackages(TestMethodMetaAnnotation.class.getPackage().getName()).enableMethodInfo()
                 .enableAnnotationInfo().scan()) {
             final List<String> testClasses = scanResult
-                    .getClassesWithMethodAnnotation(MetaAnnotation.class.getName()).getNames();
+                    .getClassesWithMethodAnnotation(MetaAnnotation.class).getNames();
             assertThat(testClasses).containsOnly(ClassWithMetaAnnotatedMethod.class.getName());
         }
     }

--- a/src/test/java/io/github/classgraph/test/parameterannotation/RetentionPolicyForFunctionParameterAnnotationsTest.java
+++ b/src/test/java/io/github/classgraph/test/parameterannotation/RetentionPolicyForFunctionParameterAnnotationsTest.java
@@ -112,7 +112,7 @@ public class RetentionPolicyForFunctionParameterAnnotationsTest {
         final MethodInfo methodInfo = classInfo.getMethodInfo()
                 .getSingleMethod("parameterAnnotation_WithRuntimeRetention");
 
-        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class.getName())).isTrue();
+        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class)).isTrue();
     }
 
     /**
@@ -142,9 +142,9 @@ public class RetentionPolicyForFunctionParameterAnnotationsTest {
         final MethodInfo methodInfo = classInfo.getMethodInfo()
                 .getSingleMethod("twoAnnotations_WithRuntimeRetention_ForSingleParam");
 
-        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class.getName())).isTrue();
+        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class)).isTrue();
 
-        assertThat(methodInfo.hasParameterAnnotation(SecondParamAnnoRuntime.class.getName())).isTrue();
+        assertThat(methodInfo.hasParameterAnnotation(SecondParamAnnoRuntime.class)).isTrue();
     }
 
     /**
@@ -168,7 +168,7 @@ public class RetentionPolicyForFunctionParameterAnnotationsTest {
         final MethodInfo methodInfo = classInfo.getMethodInfo()
                 .getSingleMethod("oneRuntimeRetention_OneClassRetention");
 
-        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class.getName())).isTrue();
+        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class)).isTrue();
     }
 
     /**
@@ -193,7 +193,7 @@ public class RetentionPolicyForFunctionParameterAnnotationsTest {
         final MethodInfo methodInfo = classInfo.getMethodInfo()
                 .getSingleMethod("oneRuntimeRetention_OneClassRetention_ChangedAnnotationOrder");
 
-        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class.getName())).isTrue();
+        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class)).isTrue();
     }
 
     /**
@@ -217,7 +217,7 @@ public class RetentionPolicyForFunctionParameterAnnotationsTest {
         final MethodInfo methodInfo = classInfo.getMethodInfo()
                 .getSingleMethod("oneRuntimeRetention_OneSourceRetention");
 
-        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class.getName())).isTrue();
+        assertThat(methodInfo.hasParameterAnnotation(ParamAnnoRuntime.class)).isTrue();
     }
 
     /**


### PR DESCRIPTION
This allows a more typesafe way of working with scan results.