### PR TITLE
`ClasspathFinder` supports overrides and `enableSystemJarsAndModules()` together

### DIFF
--- a/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
+++ b/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
@@ -284,16 +284,15 @@ public class ClasspathFinder {
             classLoaderOrderRespectingParentDelegation = finalClassLoaderOrder.toArray(new ClassLoader[0]);
         }
 
+        // Never scan java.class.path if classloaders or classpath are overridden
+        if (scanSpec.overrideClassLoaders != null || scanSpec.overrideClasspath != null) {
+            return;
+        }
 
-
-        // Only scan java.class.path if parent classloaders are not ignored, classloaders are not overridden,
-        // and the classpath is not overridden, unless only module scanning was enabled, and an unnamed module
+        // Scan java.class.path if parent classloaders are not ignored, or if module scanning was enabled and an unnamed module
         // layer was encountered -- in this case, have to forcibly scan java.class.path, since the ModuleLayer
         // API doesn't allow for the opening of unnamed modules.
-        if ((!scanSpec.ignoreParentClassLoaders && scanSpec.overrideClassLoaders == null
-                && scanSpec.overrideClasspath == null)
-                || (moduleFinder != null && moduleFinder.forceScanJavaClassPath()&& scanSpec.overrideClassLoaders == null
-                && scanSpec.overrideClasspath == null)) {
+        if ((!scanSpec.ignoreParentClassLoaders) || (moduleFinder != null && moduleFinder.forceScanJavaClassPath())) {
             final String[] pathElements = JarUtils.smartPathSplit(System.getProperty("java.class.path"), scanSpec);
             if (pathElements.length > 0) {
                 final LogNode sysPropLog = classpathFinderLog == null ? null

--- a/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
+++ b/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
@@ -121,7 +121,10 @@ public class ClasspathFinder {
         // If so, need to enable module scanning. If not, disable module scanning, since only the provided
         // classloader(s) should be scanned. (#382)
         boolean scanModules;
-        if (scanSpec.overrideClasspath != null) {
+        if (scanSpec.enableSystemJarsAndModules) {
+            // Always scan modules if system modules are enabled
+            scanModules = true;
+        } else if (scanSpec.overrideClasspath != null) {
             // Don't scan modules if classpath is overridden
             scanModules = false;
         } else if (scanSpec.overrideClassLoaders != null) {
@@ -281,13 +284,16 @@ public class ClasspathFinder {
             classLoaderOrderRespectingParentDelegation = finalClassLoaderOrder.toArray(new ClassLoader[0]);
         }
 
+
+
         // Only scan java.class.path if parent classloaders are not ignored, classloaders are not overridden,
         // and the classpath is not overridden, unless only module scanning was enabled, and an unnamed module
         // layer was encountered -- in this case, have to forcibly scan java.class.path, since the ModuleLayer
         // API doesn't allow for the opening of unnamed modules.
         if ((!scanSpec.ignoreParentClassLoaders && scanSpec.overrideClassLoaders == null
                 && scanSpec.overrideClasspath == null)
-                || (moduleFinder != null && moduleFinder.forceScanJavaClassPath())) {
+                || (moduleFinder != null && moduleFinder.forceScanJavaClassPath()&& scanSpec.overrideClassLoaders == null
+                && scanSpec.overrideClasspath == null)) {
             final String[] pathElements = JarUtils.smartPathSplit(System.getProperty("java.class.path"), scanSpec);
             if (pathElements.length > 0) {
                 final LogNode sysPropLog = classpathFinderLog == null ? null

--- a/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
+++ b/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
@@ -118,29 +118,30 @@ public class ClasspathFinder {
         final LogNode classpathFinderLog = log == null ? null : log.log("Finding classpath and modules");
 
         // If classloaders are overridden, check if the override classloader(s) is/are JPMS classloaders.
-        // If so, need to enable module scanning. If not, disable module scanning, since only the provided
-        // classloader(s) should be scanned. (#382)
-        boolean scanModules;
-        if (scanSpec.enableSystemJarsAndModules) {
-            // Always scan modules if system modules are enabled
-            scanModules = true;
-        } else if (scanSpec.overrideClasspath != null) {
-            // Don't scan modules if classpath is overridden
-            scanModules = false;
+        // If so, need to enable non-system module scanning.
+        boolean scanNonSystemModules;
+        if (scanSpec.overrideClasspath != null) {
+            // Don't scan non-system modules if classpath is overridden
+            scanNonSystemModules = false;
         } else if (scanSpec.overrideClassLoaders != null) {
-            // If classloaders are overridden, only scan modules if an override classloader is a JPMS 
+            // If classloaders are overridden, only scan non-system modules if an override classloader is a JPMS
             // AppClassLoader or PlatformClassLoader
-            scanModules = false;
+            scanNonSystemModules = false;
             for (final ClassLoader classLoader : scanSpec.overrideClassLoaders) {
                 final String classLoaderClassName = classLoader.getClass().getName();
                 // It's not possible to instantiate AppClassLoader or PlatformClassLoader, so if these are
                 // passed in as override classloaders, they must have been obtained using
                 // Thread.currentThread().getContextClassLoader() [.getParent()] or similar
                 if (classLoaderClassName.equals("jdk.internal.loader.ClassLoaders$AppClassLoader")) {
-                    scanModules = true;
+                    if (!scanSpec.enableSystemJarsAndModules) {
+                        if (classpathFinderLog != null) {
+                            classpathFinderLog.log("overrideClassLoaders() was called with an instance of "
+                                    + "jdk.internal.loader.ClassLoaders$AppClassLoader, which is a system "
+                                    + "classloader, so enableSystemJarsAndModules() was called automatically");
+                        }
+                        scanSpec.enableSystemJarsAndModules = true;
+                    }
                 } else if (classLoaderClassName.equals("jdk.internal.loader.ClassLoaders$PlatformClassLoader")) {
-                    scanModules = true;
-                    // The platform classloader was passed in, so specifically enable system module scanning
                     if (!scanSpec.enableSystemJarsAndModules) {
                         if (classpathFinderLog != null) {
                             classpathFinderLog.log("overrideClassLoaders() was called with an instance of "
@@ -152,14 +153,15 @@ public class ClasspathFinder {
                 }
             }
         } else {
-            // If classloaders are not overridden and classpath is not overridden, only scan modules
+            // If classloaders are not overridden and classpath is not overridden, only scan non-system modules
             // if module scanning is enabled
-            scanModules = scanSpec.scanModules;
+            scanNonSystemModules = scanSpec.scanModules;
         }
 
-        moduleFinder = scanModules
+        // Only instantiate a module finder if requested
+        moduleFinder = scanSpec.enableSystemJarsAndModules || scanSpec.scanModules
                 ? new ModuleFinder(CallStackReader.getClassContext(classpathFinderLog), scanSpec,
-                        classpathFinderLog)
+                        scanNonSystemModules, classpathFinderLog)
                 : null;
 
         classpathOrder = new ClasspathOrder(scanSpec);
@@ -284,15 +286,13 @@ public class ClasspathFinder {
             classLoaderOrderRespectingParentDelegation = finalClassLoaderOrder.toArray(new ClassLoader[0]);
         }
 
-        // Never scan java.class.path if classloaders or classpath are overridden
-        if (scanSpec.overrideClassLoaders != null || scanSpec.overrideClasspath != null) {
-            return;
-        }
-
-        // Scan java.class.path if parent classloaders are not ignored, or if module scanning was enabled and an unnamed module
+        // Only scan java.class.path if parent classloaders are not ignored, classloaders are not overridden,
+        // and the classpath is not overridden, unless only module scanning was enabled, and an unnamed module
         // layer was encountered -- in this case, have to forcibly scan java.class.path, since the ModuleLayer
         // API doesn't allow for the opening of unnamed modules.
-        if ((!scanSpec.ignoreParentClassLoaders) || (moduleFinder != null && moduleFinder.forceScanJavaClassPath())) {
+        if ((!scanSpec.ignoreParentClassLoaders && scanSpec.overrideClassLoaders == null
+                && scanSpec.overrideClasspath == null)
+                || (moduleFinder != null && moduleFinder.forceScanJavaClassPath())) {
             final String[] pathElements = JarUtils.smartPathSplit(System.getProperty("java.class.path"), scanSpec);
             if (pathElements.length > 0) {
                 final LogNode sysPropLog = classpathFinderLog == null ? null

--- a/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
+++ b/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
@@ -187,9 +187,10 @@ public class ClasspathFinder {
                         + "context classloader");
             }
             classLoaderOrderRespectingParentDelegation = contextClassLoaders;
+        }
 
-        } else if (scanSpec.overrideClassLoaders == null) {
-            // If system jars are not rejected, add JRE rt.jar to the beginning of the classpath
+        // If system jars are enabled, add JRE rt.jar to the beginning of the classpath
+        if (scanSpec.enableSystemJarsAndModules) {
             final String jreRtJar = SystemJarFinder.getJreRtJarPath();
 
             // Add rt.jar and/or lib/ext jars to beginning of classpath, if enabled

--- a/src/test/java/nonapi/io/github/classgraph/classpath/ClasspathFinderTest.java
+++ b/src/test/java/nonapi/io/github/classgraph/classpath/ClasspathFinderTest.java
@@ -17,6 +17,7 @@ import java.util.TreeSet;
 
 import static nonapi.io.github.classgraph.classpath.SystemJarFinder.getJreRtJarPath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClasspathFinderTest {
@@ -80,6 +81,74 @@ public class ClasspathFinderTest {
         }
         assertTrue(paths.remove(classesDir), "Classpath should have contained " + classesDir + ": " + paths);
         assertTrue(paths.remove(Paths.get(getJreRtJarPath())), "Classpath should have contained system jars: " + paths);
+        assertEquals(0, paths.size(), "Classpath should have no other entries: " + paths);
+    }
+
+    /**
+     * Test that {@link ScanSpec#enableSystemJarsAndModules}, {@link ScanSpec#ignoreParentClassLoaders}, and
+     * {@link ScanSpec#overrideClasspath} work in combination:
+     * <p>
+     * Only the system modules and the override classpath should be found.
+     */
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_9)
+    public void testOverrideClasspathAndEnableSystemModules(@TempDir Path tmpDir) throws Exception {
+        // Arrange
+        final Path classesDir = tmpDir.toAbsolutePath().normalize().toRealPath();
+        final ScanSpec scanSpec = new ScanSpec();
+        scanSpec.enableSystemJarsAndModules = true;
+        scanSpec.ignoreParentClassLoaders = true;
+        scanSpec.overrideClasspath = Collections.<Object>singletonList(classesDir);
+
+        // Act
+        final ClasspathFinder classpathFinder = new ClasspathFinder(scanSpec, new LogNode());
+        final ModuleFinder moduleFinder = classpathFinder.getModuleFinder();
+
+        // Assert
+        assertNotNull(moduleFinder, "ModuleFinder should be non-null");
+        assertTrue(moduleFinder.getSystemModuleRefs().size() > 0, "ModuleFinder should have found system modules");
+
+        final Set<Path> paths = new TreeSet<>();
+        for (final String path : classpathFinder
+                .getClasspathOrder()
+                .getClasspathEntryUniqueResolvedPaths()) {
+            paths.add(Paths.get(path));
+        }
+        assertTrue(paths.remove(classesDir), "Classpath should have contained " + classesDir + ": " + paths);
+        assertEquals(0, paths.size(), "Classpath should have no other entries: " + paths);
+    }
+
+    /**
+     * Test that {@link ScanSpec#enableSystemJarsAndModules}, {@link ScanSpec#ignoreParentClassLoaders}, and
+     * {@link ScanSpec#overrideClassLoaders} work in combination:
+     * <p>
+     * Only the system modules and the override classloaders should be found.
+     */
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_9)
+    public void testOverrideClassLoaderAndEnableSystemModules(@TempDir Path tmpDir) throws Exception {
+        // Arrange
+        final Path classesDir = tmpDir.toAbsolutePath().normalize().toRealPath();
+        final ScanSpec scanSpec = new ScanSpec();
+        scanSpec.enableSystemJarsAndModules = true;
+        scanSpec.ignoreParentClassLoaders = true;
+        scanSpec.overrideClassLoaders(new URLClassLoader(new URL[]{classesDir.toUri().toURL()}));
+
+        // Act
+        final ClasspathFinder classpathFinder = new ClasspathFinder(scanSpec, new LogNode());
+        final ModuleFinder moduleFinder = classpathFinder.getModuleFinder();
+
+        // Assert
+        assertNotNull(moduleFinder, "ModuleFinder should be non-null");
+        assertTrue(moduleFinder.getSystemModuleRefs().size() > 0, "ModuleFinder should have found system modules");
+
+        final Set<Path> paths = new TreeSet<>();
+        for (final String path : classpathFinder
+                .getClasspathOrder()
+                .getClasspathEntryUniqueResolvedPaths()) {
+            paths.add(Paths.get(path));
+        }
+        assertTrue(paths.remove(classesDir), "Classpath should have contained " + classesDir + ": " + paths);
         assertEquals(0, paths.size(), "Classpath should have no other entries: " + paths);
     }
 }

--- a/src/test/java/nonapi/io/github/classgraph/classpath/ClasspathFinderTest.java
+++ b/src/test/java/nonapi/io/github/classgraph/classpath/ClasspathFinderTest.java
@@ -1,0 +1,85 @@
+package nonapi.io.github.classgraph.classpath;
+
+import nonapi.io.github.classgraph.scanspec.ScanSpec;
+import nonapi.io.github.classgraph.utils.LogNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static nonapi.io.github.classgraph.classpath.SystemJarFinder.getJreRtJarPath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ClasspathFinderTest {
+
+    /**
+     * Test that {@link ScanSpec#enableSystemJarsAndModules}, {@link ScanSpec#ignoreParentClassLoaders}, and
+     * {@link ScanSpec#overrideClasspath} work in combination:
+     * <p>
+     * Only the system jars and the override classpath should be found.
+     */
+    @Test
+    @EnabledForJreRange(max = JRE.JAVA_8)
+    public void testOverrideClasspathAndEnableSystemJars(@TempDir Path tmpDir) throws Exception {
+        // Arrange
+        final Path classesDir = tmpDir.toAbsolutePath().normalize().toRealPath();
+        final ScanSpec scanSpec = new ScanSpec();
+        scanSpec.enableSystemJarsAndModules = true;
+        scanSpec.ignoreParentClassLoaders = true;
+        scanSpec.overrideClasspath = Collections.singletonList(classesDir);
+
+        // Act
+        final ClasspathFinder classpathFinder = new ClasspathFinder(scanSpec, new LogNode());
+
+        // Assert
+        final Set<Path> paths = new TreeSet<>();
+        for (final String path : classpathFinder
+                .getClasspathOrder()
+                .getClasspathEntryUniqueResolvedPaths()) {
+            paths.add(Paths.get(path));
+        }
+        assertTrue(paths.remove(classesDir), "Classpath should have contained " + classesDir + ": " + paths);
+        assertTrue(paths.remove(Paths.get(getJreRtJarPath())), "Classpath should have contained system jars: " + paths);
+        assertEquals(0, paths.size(), "Classpath should have no other entries: " + paths);
+    }
+
+    /**
+     * Test that {@link ScanSpec#enableSystemJarsAndModules}, {@link ScanSpec#ignoreParentClassLoaders}, and
+     * {@link ScanSpec#overrideClassLoaders} work in combination:
+     * <p>
+     * Only the system jars and the override classloaders should be found.
+     */
+    @Test
+    @EnabledForJreRange(max = JRE.JAVA_8)
+    public void testOverrideClassLoaderAndEnableSystemJars(@TempDir Path tmpDir) throws Exception {
+        // Arrange
+        final Path classesDir = tmpDir.toAbsolutePath().normalize().toRealPath();
+        final ScanSpec scanSpec = new ScanSpec();
+        scanSpec.enableSystemJarsAndModules = true;
+        scanSpec.ignoreParentClassLoaders = true;
+        scanSpec.overrideClassLoaders(new URLClassLoader(new URL[]{classesDir.toUri().toURL()}));
+
+        // Act
+        final ClasspathFinder classpathFinder = new ClasspathFinder(scanSpec, new LogNode());
+
+        // Assert
+        final Set<Path> paths = new TreeSet<>();
+        for (final String path : classpathFinder
+                .getClasspathOrder()
+                .getClasspathEntryUniqueResolvedPaths()) {
+            paths.add(Paths.get(path));
+        }
+        assertTrue(paths.remove(classesDir), "Classpath should have contained " + classesDir + ": " + paths);
+        assertTrue(paths.remove(Paths.get(getJreRtJarPath())), "Classpath should have contained system jars: " + paths);
+        assertEquals(0, paths.size(), "Classpath should have no other entries: " + paths);
+    }
+}


### PR DESCRIPTION
- Previously `enableSystemJarsAndModules()` was ignored if overriding the classpath / classloader. This change allows the two to be used together if desired. 
- Unamed modules from the parent classloader are excluded if the claspath / classloader is overridden. 
  - IIUC this was matches the comment and presumably the intended behaviour:
    > Only scan java.class.path if parent classloaders are not ignored, classloaders are not overridden, and the classpath is not overridden, unless only module scanning was enabled, and an unnamed module layer was encountered