### PR TITLE
fix AccessControlException from SecurityManager in ClasspathOrder

### DIFF
--- a/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathOrder.java
+++ b/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathOrder.java
@@ -319,14 +319,18 @@ public class ClasspathOrder {
                 final String pathElementToStr = pathElement.toString();
                 try {
                     pathElementURL = new File(pathElementToStr).toURI().toURL();
-                } catch (final MalformedURLException e) {
+                } catch (final MalformedURLException | SecurityException e) {
+                    if (log != null) {
+                        log.log("Failed to convert classpath element to URL, "
+                                + "Try prepending \"file:\" to create a URL (" + e + "): " + pathElementStr );
+                    }
                     // Final fallback -- try prepending "file:" to create a URL
                     pathElementURL = new URL("file:" + pathElementToStr);
                 }
             }
-        } catch (final MalformedURLException e1) {
+        } catch (final MalformedURLException |SecurityException e1) {
             if (log != null) {
-                log.log("Cannot convert to URL: " + pathElement);
+                log.log("Cannot convert to URL (" + e1 + "): " + pathElement );
             }
             pathElementURL = null;
         }


### PR DESCRIPTION
Hi @lukehutch,

yes, it's me and SecurityManger again =)

We have a new SecurityException after upgrading from 4.8.69 to 4.8.129 with our SecurityManager enabled Tomcat target platform.

In ClasspathOrder, class path elements are converted to URLs by `pathElementURL = new File(pathElementToStr).toURI().toURL()`.

File#toUri() requires read access to the directory containing the file. If the JVM is running with SecurityManager enabled, this file system access may represent a security policy violation (e.g., in Tomcat, the `CATALINA_HOME/bin` folder containing classpath elements such as bootstrap.jar, etc.).
In this case, the existing fallback handling can be used.

This PR works fine in our case, but we are only searching for some WebJars.