### PR TITLE
Mark resolution of jdk.internal.misc as optional (again)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
                                 <Export-Package>io.github.classgraph;version="${project.version}"</Export-Package>
                                 <!-- Make sure "requires" entries in the module descriptor match these imports: -->
                                 <!-- src/main/module-info/io.github.classgraph/module-info.java -->
-                                <Import-Package>javax.xml.xpath,javax.xml.namespace,javax.xml.parsers,org.w3c.dom,jdk.internal.misc,io.github.toolfactory.jvm;resolution:="optional",sun.misc;resolution:="optional",sun.nio.ch;resolution:="optional"</Import-Package>
+                                <Import-Package>javax.xml.xpath,javax.xml.namespace,javax.xml.parsers,org.w3c.dom,jdk.internal.misc;resolution:="optional",io.github.toolfactory.jvm;resolution:="optional",sun.misc;resolution:="optional",sun.nio.ch;resolution:="optional"</Import-Package>
                                 <!-- This is a multi-release jar, since module-info.class will be added to -->
                                 <!-- META-INF/versions/9 , so we need to set the Multi-Release entry to true -->
                                 <Multi-Release>true</Multi-Release>


### PR DESCRIPTION
jdk.internal.misc was marked optional in https://github.com/classgraph/classgraph/issues/408. I think this resolution attribute was unintentionally removed, when jvm.driver was added with this commit: https://github.com/classgraph/classgraph/commit/4c30481ada042af58f7ad03292fc411e276dfc47