### PR TITLE
Closing ClassfileReader must also close its underlying Resource.

### DIFF
--- a/src/main/java/nonapi/io/github/classgraph/fileslice/Slice.java
+++ b/src/main/java/nonapi/io/github/classgraph/fileslice/Slice.java
@@ -263,7 +263,7 @@ public abstract class Slice implements Closeable {
             throw new IllegalArgumentException(
                     "Cannot open slices larger than 2GB for sequential buffered reading");
         }
-        return new ClassfileReader(this);
+        return new ClassfileReader(this, null);
     }
 
     /**

--- a/src/test/java/io/github/classgraph/issues/issue600/Issue600Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue600/Issue600Test.java
@@ -1,0 +1,98 @@
+package io.github.classgraph.issues.issue600;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.Resource;
+import io.github.classgraph.ResourceList;
+import io.github.classgraph.ScanResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Issue600Test {
+    private static final int BUFFER_SIZE = 8192;
+    private static final int EOF = -1;
+
+    private final ClassGraph classGraph = new ClassGraph()
+        .enableClassInfo()
+        .acceptPackages(getClass().getPackage().getName());
+
+    @Test
+    void testResourcesCanBeOpened() {
+        try (ScanResult scanResult = classGraph.scan()) {
+            ResourceList resources = scanResult.getAllResources();
+            assertFalse(resources.isEmpty(), "Test is meaningless without resources to open.");
+
+            // Check we can open the resources.
+            assertOpenCloseResources(resources);
+
+            // And check we can reopen the resources.
+            assertOpenCloseResources(resources);
+        }
+    }
+
+    @Test
+    void testResourcesCanBeRead() {
+        try (ScanResult scanResult = classGraph.scan()) {
+            ResourceList resources = scanResult.getAllResources();
+            assertFalse(resources.isEmpty(), "Test is meaningless without resources to open.");
+
+            // Check we can read the resources.
+            assertReadCloseResources(resources);
+
+            // Check we can reread the resources.
+            assertReadCloseResources(resources);
+        }
+    }
+
+    private void assertOpenCloseResources(ResourceList resources) {
+        for (final Resource resource : resources) {
+            assertDoesNotThrow(new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    try (InputStream input = resource.open()) {
+                        assertThat(consume(input)).isGreaterThan(0);
+                    }
+                }
+            }, "Resource " + resource.getPath() + " should be closed.");
+        }
+    }
+
+    private int consume(InputStream input) throws IOException {
+        byte[] buffer = new byte[BUFFER_SIZE];
+        int totalBytes = 0;
+        int bytesRead;
+        while ((bytesRead = input.read(buffer)) != EOF) {
+            totalBytes += bytesRead;
+        }
+        return totalBytes;
+    }
+
+    private void assertReadCloseResources(ResourceList resources) {
+        for (final Resource resource : resources) {
+            assertDoesNotThrow(new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    ByteBuffer buffer = resource.read();
+                    try {
+                        assertTrue(buffer.hasRemaining());
+                    } finally {
+                        resource.close();
+                    }
+                }
+            }, "Resource " + resource.getPath() + " should be closed.");
+        }
+    }
+
+    public interface Api {}
+
+    @SuppressWarnings("unused")
+    public static class Example implements Api {}
+}


### PR DESCRIPTION
Upgrading from 4.8.90 to 4.8.133, I have noticed that the resources returned by `scanResult.allResources` are now in an "open" state, such that invoking `open()` on them throws an `IOException` with the message:
> "Resource is already open -- cannot open it again without first calling close()"

I believe I have a fix for this, and am currently trying to write some test cases.