### PR TITLE
Only invoke Resource's super.close() if the resource is open.

### DIFF
--- a/src/main/java/io/github/classgraph/ClasspathElementFileDir.java
+++ b/src/main/java/io/github/classgraph/ClasspathElementFileDir.java
@@ -182,9 +182,7 @@ class ClasspathElementFileDir extends ClasspathElement {
             private final Runnable onClose = new Runnable() {
                 @Override
                 public void run() {
-                    if (isOpen.get()) {
-                        close();
-                    }
+                    close();
                 }
             };
 
@@ -298,8 +296,10 @@ class ClasspathElementFileDir extends ClasspathElement {
                         nestedJarHandler.markSliceAsClosed(fileSlice);
                         fileSlice = null;
                     }
+
+                    // Close inputStream
+                    super.close();
                 }
-                super.close(); // Close inputStream
             }
         };
     }

--- a/src/main/java/io/github/classgraph/ClasspathElementPathDir.java
+++ b/src/main/java/io/github/classgraph/ClasspathElementPathDir.java
@@ -187,9 +187,7 @@ class ClasspathElementPathDir extends ClasspathElement {
             private final Runnable onClose = new Runnable() {
                 @Override
                 public void run() {
-                    if (isOpen.get()) {
-                        close();
-                    }
+                    close();
                 }
             };
 
@@ -304,8 +302,10 @@ class ClasspathElementPathDir extends ClasspathElement {
                         nestedJarHandler.markSliceAsClosed(pathSlice);
                         pathSlice = null;
                     }
+
+                    // Close inputStream
+                    super.close();
                 }
-                super.close(); // Close inputStream
             }
         };
     }

--- a/src/main/java/io/github/classgraph/ClasspathElementZip.java
+++ b/src/main/java/io/github/classgraph/ClasspathElementZip.java
@@ -322,9 +322,7 @@ class ClasspathElementZip extends ClasspathElement {
             private final Runnable onClose = new Runnable() {
                 @Override
                 public void run() {
-                    if (isOpen.get()) {
-                        close();
-                    }
+                    close();
                 }
             };
 
@@ -455,12 +453,16 @@ class ClasspathElementZip extends ClasspathElement {
 
             @Override
             public void close() {
-                if (isOpen.getAndSet(false) && byteBuffer != null) {
-                    // ByteBuffer should be a duplicate or slice, or should wrap an array, so it doesn't
-                    // need to be unmapped
-                    byteBuffer = null;
+                if (isOpen.getAndSet(false)) {
+                    if (byteBuffer != null) {
+                        // ByteBuffer should be a duplicate or slice, or should wrap an array, so it doesn't
+                        // need to be unmapped
+                        byteBuffer = null;
+                    }
+
+                    // Close inputStream
+                    super.close();
                 }
-                super.close(); // Close inputStream
             }
         };
     }


### PR DESCRIPTION
Protect `Resource`'s `super.close()` invocation using `Resource.isOpen`. This allows us to simplify the `onClose` handlers only to invoke `Resource.close()`.

Maybe one day the `onClose` handler can then be replaced by just `Resource::close`.