### PR TITLE
Fix QuarkusClassLoaderHandler on Quarkus 2.7.

### DIFF
--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/QuarkusClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/QuarkusClassLoaderHandler.java
@@ -127,6 +127,13 @@ class QuarkusClassLoaderHandler implements ClassLoaderHandler {
             } else if ("io.quarkus.bootstrap.classloading.DirectoryClassPathElement".equals(elementClassName)) {
                 classpathOrder.addClasspathEntry(ReflectionUtils.getFieldVal(false, element, "root"), classLoader,
                         scanSpec, log);
+            } else {
+                Object rootPath = ReflectionUtils.invokeMethod(false, element, "getRoot");
+                if (rootPath instanceof Path) {
+                    classpathOrder.addClasspathEntry(ReflectionUtils.invokeMethod(false, element, "getRoot"),
+                        classLoader,
+                        scanSpec, log);
+                }
             }
         }
     }


### PR DESCRIPTION
In Quarkus 2.7, the class loader stopped returning `JarClassPathElement`
or `DirectoryClassPathElement` entries. Instead, some implementation of
`ClassPathElement` is returned. This change tries to access it's
`getRoot` method, returning a `java.nio.file.Path` pointing to the root
of the element, as supported with class graph.

The behaviour has been verified on Quarkus 2.6 and Quarkus 2.7.

This is a fix for #641, thanks @lukehutch in advance for considering this input. It would help Neo4j a lot.