### PR TITLE
Add `getTypeAnnotationInfo` to `TypeParameter` and `TypeArgument`

### DIFF
--- a/src/main/java/io/github/classgraph/TypeArgument.java
+++ b/src/main/java/io/github/classgraph/TypeArgument.java
@@ -225,6 +225,15 @@ public final class TypeArgument extends HierarchicalTypeSignature {
         }
     }
 
+    /**
+     * Get a list of {@link AnnotationInfo} objects for any type annotations before the type argument wildcard, or null if none.
+     * 
+     * @return a list of {@link AnnotationInfo} objects for any type annotations before the type argument wildcard, or null if none.
+     */
+    public AnnotationInfoList getTypeAnnotationInfo() {
+        return typeAnnotationInfo;
+    }
+
     // -------------------------------------------------------------------------------------------------------------
 
     /* (non-Javadoc)

--- a/src/main/java/io/github/classgraph/TypeParameter.java
+++ b/src/main/java/io/github/classgraph/TypeParameter.java
@@ -97,6 +97,15 @@ public final class TypeParameter extends HierarchicalTypeSignature {
         return interfaceBounds;
     }
 
+    /**
+     * Get a list of {@link AnnotationInfo} objects for any type annotations on this type parameter, or null if none.
+     * 
+     * @return a list of {@link AnnotationInfo} objects for any type annotations on this type parameter, or null if none.
+     */
+    public AnnotationInfoList getTypeAnnotationInfo() {
+        return typeAnnotationInfo;
+    }
+
     @Override
     protected void addTypeAnnotation(final List<TypePathNode> typePath, final AnnotationInfo annotationInfo) {
         if (typePath.isEmpty()) {

--- a/src/test/java/io/github/classgraph/issues/issue741/TypeArgumentAnnotationTest.java
+++ b/src/test/java/io/github/classgraph/issues/issue741/TypeArgumentAnnotationTest.java
@@ -1,0 +1,53 @@
+package io.github.classgraph.issues.issue741;
+
+import io.github.classgraph.*;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeArgumentAnnotationTest {
+    @Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    private static @interface A {
+    }
+
+    @Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    private static @interface B {
+        String value();
+    }
+
+    @Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    private static @interface C {
+        Class<?> t();
+    }
+
+    @Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    private static @interface D {
+        int n();
+    }
+
+    static class U {
+    }
+
+    void setValueList(List<@A @B("foo") @C(t=U.class) @D(n=50) ?> valueList) {
+    }
+
+    @Test
+    void typeArgumentAnnotation() {
+        try (final ScanResult scanResult = new ClassGraph().acceptPackages(TypeArgumentAnnotationTest.class.getPackage().getName())
+                .enableAllInfo().scan()) {
+            final ClassInfo cls = scanResult.getClassInfo(TypeArgumentAnnotationTest.class.getName());
+            final MethodInfo method = cls.getMethodInfo().get("setValueList").get(0);
+            final MethodParameterInfo parameterInfo = method.getParameterInfo()[0];
+            final TypeArgument typeArgument = ((ClassRefTypeSignature) parameterInfo.getTypeSignatureOrTypeDescriptor()).getTypeArguments().get(0);
+            final AnnotationInfoList annotationInfoList = typeArgument.getTypeAnnotationInfo();
+            assertThat(annotationInfoList.get(0).toStringWithSimpleNames()).isEqualTo("@A");
+            assertThat(annotationInfoList.get(1).toStringWithSimpleNames()).isEqualTo("@B(\"foo\")");
+            assertThat(annotationInfoList.get(2).toStringWithSimpleNames()).isEqualTo("@C(t=U.class)");
+            assertThat(annotationInfoList.get(3).toStringWithSimpleNames()).isEqualTo("@D(n=50)");
+        }
+    }
+}

--- a/src/test/java/io/github/classgraph/issues/issue741/TypeParameterAnnotationTest.java
+++ b/src/test/java/io/github/classgraph/issues/issue741/TypeParameterAnnotationTest.java
@@ -1,0 +1,51 @@
+package io.github.classgraph.issues.issue741;
+
+import io.github.classgraph.*;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeParameterAnnotationTest {
+    @Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    private static @interface A {
+    }
+
+    @Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    private static @interface B {
+        String value();
+    }
+
+    @Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    private static @interface C {
+        Class<?> t();
+    }
+
+    @Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+    private static @interface D {
+        int n();
+    }
+
+    static class U {
+    }
+
+    <@A @B("foo") @C(t=U.class) @D(n=50) T> void setValue(T value) {
+    }
+
+    @Test
+    void typeParameterAnnotation() {
+        try (final ScanResult scanResult = new ClassGraph().acceptPackages(TypeParameterAnnotationTest.class.getPackage().getName())
+                .enableAllInfo().scan()) {
+            final ClassInfo cls = scanResult.getClassInfo(TypeParameterAnnotationTest.class.getName());
+            final MethodInfo method = cls.getMethodInfo().get("setValue").get(0);
+            final TypeParameter typeParameter = method.getTypeSignatureOrTypeDescriptor().getTypeParameters().get(0);
+            final AnnotationInfoList annotationInfoList = typeParameter.getTypeAnnotationInfo();
+            assertThat(annotationInfoList.get(0).toStringWithSimpleNames()).isEqualTo("@A");
+            assertThat(annotationInfoList.get(1).toStringWithSimpleNames()).isEqualTo("@B(\"foo\")");
+            assertThat(annotationInfoList.get(2).toStringWithSimpleNames()).isEqualTo("@C(t=U.class)");
+            assertThat(annotationInfoList.get(3).toStringWithSimpleNames()).isEqualTo("@D(n=50)");
+        }
+    }
+}


### PR DESCRIPTION
Fixes classgraph/classgraph#741

Exposes missing API for accessing parsed annotations on type parameters and wildcard type arguments.