### PR TITLE
#772 Fix method override order

### DIFF
--- a/src/test/java/io/github/classgraph/issues/issue772/ExampleA.java
+++ b/src/test/java/io/github/classgraph/issues/issue772/ExampleA.java
@@ -1,0 +1,14 @@
+package io.github.classgraph.issues.issue772;
+
+/**
+ * Test case A for selecting the 'Close' method of Child.
+ * Rather simple case of symmetrical extending classes.
+ */
+@SuppressWarnings("unused")
+public abstract class ExampleA implements AutoCloseable {
+
+
+   public abstract static class Child extends ExampleA implements MyCloseable {
+
+   }
+}

--- a/src/test/java/io/github/classgraph/issues/issue772/ExampleA.java
+++ b/src/test/java/io/github/classgraph/issues/issue772/ExampleA.java
@@ -8,7 +8,7 @@ package io.github.classgraph.issues.issue772;
 public abstract class ExampleA implements AutoCloseable {
 
 
-   public abstract static class Child extends ExampleA implements MyCloseable {
+    public abstract static class Child extends ExampleA implements MyCloseable {
 
-   }
+    }
 }

--- a/src/test/java/io/github/classgraph/issues/issue772/ExampleB.java
+++ b/src/test/java/io/github/classgraph/issues/issue772/ExampleB.java
@@ -1,0 +1,9 @@
+package io.github.classgraph.issues.issue772;
+
+@SuppressWarnings("unused")
+public abstract class ExampleB implements MyCloseable {
+
+   public abstract static class Child extends ExampleB implements AutoCloseable {
+
+   }
+}

--- a/src/test/java/io/github/classgraph/issues/issue772/ExampleB.java
+++ b/src/test/java/io/github/classgraph/issues/issue772/ExampleB.java
@@ -3,7 +3,7 @@ package io.github.classgraph.issues.issue772;
 @SuppressWarnings("unused")
 public abstract class ExampleB implements MyCloseable {
 
-   public abstract static class Child extends ExampleB implements AutoCloseable {
+    public abstract static class Child extends ExampleB implements AutoCloseable {
 
-   }
+    }
 }

--- a/src/test/java/io/github/classgraph/issues/issue772/ExampleC.java
+++ b/src/test/java/io/github/classgraph/issues/issue772/ExampleC.java
@@ -1,0 +1,11 @@
+package io.github.classgraph.issues.issue772;
+
+@SuppressWarnings("unused")
+public abstract class ExampleC implements AutoCloseable {
+
+   public abstract void close();
+
+   public abstract static class Child extends ExampleC implements MyCloseable {
+
+   }
+}

--- a/src/test/java/io/github/classgraph/issues/issue772/ExampleC.java
+++ b/src/test/java/io/github/classgraph/issues/issue772/ExampleC.java
@@ -3,9 +3,9 @@ package io.github.classgraph.issues.issue772;
 @SuppressWarnings("unused")
 public abstract class ExampleC implements AutoCloseable {
 
-   public abstract void close();
+    public abstract void close();
 
-   public abstract static class Child extends ExampleC implements MyCloseable {
+    public abstract static class Child extends ExampleC implements MyCloseable {
 
-   }
+    }
 }

--- a/src/test/java/io/github/classgraph/issues/issue772/MethodOverrideOrderTest.java
+++ b/src/test/java/io/github/classgraph/issues/issue772/MethodOverrideOrderTest.java
@@ -1,0 +1,77 @@
+package io.github.classgraph.issues.issue772;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.MethodInfoList;
+import io.github.classgraph.ScanResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the order of classes overriding one another when selecting methods
+ */
+public class MethodOverrideOrderTest {
+
+   private static ScanResult scanResult;
+
+   @BeforeAll
+   public static void setup() {
+      scanResult = new ClassGraph()
+              .acceptPackages(MethodOverrideOrderTest.class.getPackage().getName())
+              .enableMethodInfo()
+              .scan();
+   }
+
+   @AfterAll
+   public static void teardown() {
+      scanResult.close();
+      scanResult = null;
+   }
+
+
+   /**
+    * Tests if the correct method is selected if a class implements from two interfaces that inherit from another.
+    * Case of the child class implementing the inherited interface.
+    */
+   @Test
+   public void interfaceMethodOrderingA() {
+      ClassInfo classInfo = scanResult.getClassInfo("io.github.classgraph.issues.issue772.ExampleA$Child");
+      assertThat(classInfo).isNotNull();
+      MethodInfoList closeMethods = classInfo.getMethodInfo("close");
+      assertThat(closeMethods.size()).isEqualTo(1);
+      assertThat(closeMethods.get(0).getClassInfo().getName()).isEqualTo("io.github.classgraph.issues.issue772.MyCloseable");
+      //Reflection in JDK8 will source the method AutoCloseable as well, works as expected from at least JDK11+
+      // ClassLoader.getSystemClassLoader().loadClass("io.github.classgraph.issues.issue772.ExampleA$Child").getMethod("close")
+   }
+
+
+   /**
+    * Tests if the correct method is selected if a class implements from two interfaces that inherit from another.
+    * Case of the child class implementing the inherited interface.
+    */
+   @Test
+   public void interfaceMethodOrderingB() {
+      ClassInfo classInfo = scanResult.getClassInfo("io.github.classgraph.issues.issue772.ExampleB$Child");
+      assertThat(classInfo).isNotNull();
+      MethodInfoList closeMethods = classInfo.getMethodInfo("close");
+      assertThat(closeMethods.size()).isEqualTo(1);
+      assertThat(closeMethods.get(0).getClassInfo().getName()).isEqualTo("io.github.classgraph.issues.issue772.MyCloseable");
+   }
+
+   /**
+    * Tests if the correct method is selected if a class implements from two interfaces that inherit from another.
+    * Case of the child class implementing the inherited interface.
+    */
+   @Test
+   public void interfaceMethodOrderingC() {
+      ClassInfo classInfo = scanResult.getClassInfo("io.github.classgraph.issues.issue772.ExampleC$Child");
+      assertThat(classInfo).isNotNull();
+      MethodInfoList closeMethods = classInfo.getMethodInfo("close");
+      assertThat(closeMethods.size()).isEqualTo(1);
+      assertThat(closeMethods.get(0).getClassInfo().getName()).isEqualTo("io.github.classgraph.issues.issue772.ExampleC");
+   }
+
+}

--- a/src/test/java/io/github/classgraph/issues/issue772/MethodOverrideOrderTest.java
+++ b/src/test/java/io/github/classgraph/issues/issue772/MethodOverrideOrderTest.java
@@ -15,63 +15,63 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class MethodOverrideOrderTest {
 
-   private static ScanResult scanResult;
+    private static ScanResult scanResult;
 
-   @BeforeAll
-   public static void setup() {
-      scanResult = new ClassGraph()
-              .acceptPackages(MethodOverrideOrderTest.class.getPackage().getName())
-              .enableMethodInfo()
-              .scan();
-   }
+    @BeforeAll
+    public static void setup() {
+        scanResult = new ClassGraph()
+                .acceptPackages(MethodOverrideOrderTest.class.getPackage().getName())
+                .enableMethodInfo()
+                .scan();
+    }
 
-   @AfterAll
-   public static void teardown() {
-      scanResult.close();
-      scanResult = null;
-   }
-
-
-   /**
-    * Tests if the correct method is selected if a class implements from two interfaces that inherit from another.
-    * Case of the child class implementing the inherited interface.
-    */
-   @Test
-   public void interfaceMethodOrderingA() {
-      ClassInfo classInfo = scanResult.getClassInfo("io.github.classgraph.issues.issue772.ExampleA$Child");
-      assertThat(classInfo).isNotNull();
-      MethodInfoList closeMethods = classInfo.getMethodInfo("close");
-      assertThat(closeMethods.size()).isEqualTo(1);
-      assertThat(closeMethods.get(0).getClassInfo().getName()).isEqualTo("io.github.classgraph.issues.issue772.MyCloseable");
-      //Reflection in JDK8 will source the method AutoCloseable as well, works as expected from at least JDK11+
-      // ClassLoader.getSystemClassLoader().loadClass("io.github.classgraph.issues.issue772.ExampleA$Child").getMethod("close")
-   }
+    @AfterAll
+    public static void teardown() {
+        scanResult.close();
+        scanResult = null;
+    }
 
 
-   /**
-    * Tests if the correct method is selected if a class implements from two interfaces that inherit from another.
-    * Case of the child class implementing the inherited interface.
-    */
-   @Test
-   public void interfaceMethodOrderingB() {
-      ClassInfo classInfo = scanResult.getClassInfo("io.github.classgraph.issues.issue772.ExampleB$Child");
-      assertThat(classInfo).isNotNull();
-      MethodInfoList closeMethods = classInfo.getMethodInfo("close");
-      assertThat(closeMethods.size()).isEqualTo(1);
-      assertThat(closeMethods.get(0).getClassInfo().getName()).isEqualTo("io.github.classgraph.issues.issue772.MyCloseable");
-   }
+    /**
+     * Tests if the correct method is selected if a class implements from two interfaces that inherit from another.
+     * Case of the child class implementing the inherited interface.
+     */
+    @Test
+    public void interfaceMethodOrderingA() {
+        ClassInfo classInfo = scanResult.getClassInfo("io.github.classgraph.issues.issue772.ExampleA$Child");
+        assertThat(classInfo).isNotNull();
+        MethodInfoList closeMethods = classInfo.getMethodInfo("close");
+        assertThat(closeMethods.size()).isEqualTo(1);
+        assertThat(closeMethods.get(0).getClassInfo().getName()).isEqualTo("io.github.classgraph.issues.issue772.MyCloseable");
+        //Reflection in JDK8 will source the method AutoCloseable as well, works as expected from at least JDK11+
+        // ClassLoader.getSystemClassLoader().loadClass("io.github.classgraph.issues.issue772.ExampleA$Child").getMethod("close")
+    }
 
-   /**
-    * Tests if the correct method is selected if a class implements from two interfaces that inherit from another.
-    * Case of the child class implementing the inherited interface.
-    */
-   @Test
-   public void interfaceMethodOrderingC() {
-      ClassInfo classInfo = scanResult.getClassInfo("io.github.classgraph.issues.issue772.ExampleC$Child");
-      assertThat(classInfo).isNotNull();
-      MethodInfoList closeMethods = classInfo.getMethodInfo("close");
-      assertThat(closeMethods.size()).isEqualTo(1);
-      assertThat(closeMethods.get(0).getClassInfo().getName()).isEqualTo("io.github.classgraph.issues.issue772.ExampleC");
-   }
+
+    /**
+     * Tests if the correct method is selected if a class implements from two interfaces that inherit from another.
+     * Case of the child class implementing the inherited interface.
+     */
+    @Test
+    public void interfaceMethodOrderingB() {
+        ClassInfo classInfo = scanResult.getClassInfo("io.github.classgraph.issues.issue772.ExampleB$Child");
+        assertThat(classInfo).isNotNull();
+        MethodInfoList closeMethods = classInfo.getMethodInfo("close");
+        assertThat(closeMethods.size()).isEqualTo(1);
+        assertThat(closeMethods.get(0).getClassInfo().getName()).isEqualTo("io.github.classgraph.issues.issue772.MyCloseable");
+    }
+
+    /**
+     * Tests if the correct method is selected if a class implements from two interfaces that inherit from another.
+     * Case of the child class implementing the inherited interface.
+     */
+    @Test
+    public void interfaceMethodOrderingC() {
+        ClassInfo classInfo = scanResult.getClassInfo("io.github.classgraph.issues.issue772.ExampleC$Child");
+        assertThat(classInfo).isNotNull();
+        MethodInfoList closeMethods = classInfo.getMethodInfo("close");
+        assertThat(closeMethods.size()).isEqualTo(1);
+        assertThat(closeMethods.get(0).getClassInfo().getName()).isEqualTo("io.github.classgraph.issues.issue772.ExampleC");
+    }
 
 }

--- a/src/test/java/io/github/classgraph/issues/issue772/MyCloseable.java
+++ b/src/test/java/io/github/classgraph/issues/issue772/MyCloseable.java
@@ -1,0 +1,13 @@
+package io.github.classgraph.issues.issue772;
+
+import java.io.Closeable;
+
+/**
+ * An interface overriding another, its methods should always be 'preferred' before methods from Closeable
+ */
+public interface MyCloseable extends Closeable {
+
+    //override close without the exception, good candidate for a default method in JDK8+
+    @Override
+    void close();
+}


### PR DESCRIPTION
Fixes order of classes overriding one another for methods, preventing getMethodInfo from returning a method that is overridden.