### PR TITLE
Never return null in getResourcesWithPath() #780

### DIFF
--- a/src/main/java/io/github/classgraph/ScanResult.java
+++ b/src/main/java/io/github/classgraph/ScanResult.java
@@ -516,12 +516,12 @@ public final class ScanResult implements Closeable, AutoCloseable {
         }
         final String path = FileUtils.sanitizeEntryPath(resourcePath, /* removeInitialSlash = */ true,
                 /* removeFinalSlash = */ true);
+        ResourceList matchingResources = null;
         if (getResourcesWithPathCallCount.incrementAndGet() > 3) {
             // If numerous calls are made, produce and cache a single HashMap for O(1) access time
-            return getAllResourcesAsMap().get(path);
+            matchingResources = getAllResourcesAsMap().get(path);
         } else {
             // If just a few calls are made, directly search for resource with the requested path
-            ResourceList matchingResources = null;
             for (final ClasspathElement classpathElt : classpathOrder) {
                 for (final Resource res : classpathElt.acceptedResources) {
                     if (res.getPath().equals(path)) {
@@ -532,8 +532,8 @@ public final class ScanResult implements Closeable, AutoCloseable {
                     }
                 }
             }
-            return matchingResources == null ? ResourceList.EMPTY_LIST : matchingResources;
         }
+        return matchingResources == null ? ResourceList.EMPTY_LIST : matchingResources;
     }
 
     /**

--- a/src/test/java/io/github/classgraph/issues/issue780/Issue780Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue780/Issue780Test.java
@@ -1,0 +1,21 @@
+package io.github.classgraph.issues.issue780;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Issue780Test {
+    /**
+     * Issue 780.
+     */
+    @Test
+    public void getResourcesWithPathShouldNeverReturnNull() {
+        try (ScanResult result = new ClassGraph().scan()) {
+            for (int i = 0; i < 10; i++) {
+                assertThat(result.getResourcesWithPath("/some/non/existing/path")).isNotNull().isEmpty();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since cd213ef getResourcesWithPath() returned null if it's called n-th times for a non-scanned or non-existing path.