### PR TITLE
Fix patched module resource lookup

### DIFF
--- a/src/main/java/io/github/classgraph/ClasspathElementModule.java
+++ b/src/main/java/io/github/classgraph/ClasspathElementModule.java
@@ -184,6 +184,20 @@ class ClasspathElementModule extends ClasspathElement {
             }
 
             @Override
+            public URI getURI() {
+                try {
+                    ModuleReaderProxy localModuleReaderProxy = moduleReaderProxyRecycler.acquire();
+                    try {
+                        return localModuleReaderProxy.find(resourcePath);
+                    } finally {
+                        moduleReaderProxyRecycler.recycle(localModuleReaderProxy);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
             public InputStream open() throws IOException {
                 if (skipClasspathElement) {
                     // Shouldn't happen

--- a/src/main/java/io/github/classgraph/ModuleReaderProxy.java
+++ b/src/main/java/io/github/classgraph/ModuleReaderProxy.java
@@ -31,6 +31,7 @@ package io.github.classgraph;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -182,5 +183,28 @@ public class ModuleReaderProxy implements Closeable {
     public void release(final ByteBuffer byteBuffer) {
         reflectionUtils.invokeMethod(/* throwException = */ true, moduleReader, "release", ByteBuffer.class,
                 byteBuffer);
+    }
+
+    /**
+     * Use the proxied ModuleReader to find the named resource as a URI.
+     *
+     * @param path
+     *            The path to the resource to open.
+     * @return A {@link URI} for the resource.
+     * @throws SecurityException
+     *             If the module cannot be accessed.
+     */
+    public URI find(final String path) {
+        final Object /* Optional<URI> */ optionalURI = reflectionUtils.invokeMethod(/* throwException = */ true, moduleReader, "find", String.class,
+                path);
+        if (optionalURI == null) {
+            throw new IllegalArgumentException("Got null result from ModuleReader#find(String)");
+        }
+        final URI uri = (URI) reflectionUtils.invokeMethod(/* throwException = */ true,
+                optionalURI, "get");
+        if (uri == null) {
+            throw new IllegalArgumentException("Got null result from ModuleReader#find(String).get()");
+        }
+        return uri;
     }
 }


### PR DESCRIPTION
The current getURI method constructs a classpath resource from the `getClasspathElementURI` method. This doesn't worked for patched modules that could come from different classpaths (for example the module may start as a jar but have a directory patched in).

Calling the `ModuleReader#find` method (https://docs.oracle.com/javase%2F9%2Fdocs%2Fapi%2F%2F/java/lang/module/ModuleReader.html#find-java.lang.String-) instead will give us the URI of the resource.

Might fix https://github.com/classgraph/classgraph/issues/704