### PR TITLE
Fix library detection in ClasspathElementDir

### DIFF
--- a/src/main/java/io/github/classgraph/ClasspathElementDir.java
+++ b/src/main/java/io/github/classgraph/ClasspathElementDir.java
@@ -112,7 +112,7 @@ class ClasspathElementDir extends ClasspathElement {
                     // Add all jarfiles within the lib dir as child classpath entries
                     try (DirectoryStream<Path> stream = Files.newDirectoryStream(libDirPath)) {
                         for (final Path filePath : stream) {
-                            if (Files.isRegularFile(filePath) && filePath.getFileName().endsWith(".jar")) {
+                            if (Files.isRegularFile(filePath) && filePath.toString().toLowerCase().endsWith(".jar")) {
                                 if (log != null) {
                                     log(classpathElementIdx, "Found lib jar: " + filePath, log);
                                 }


### PR DESCRIPTION
Change Path#endsWith to Path#toString#endsWith. As Path#endsWith only matches full path segments. And therefore no library inside the AUTOMATIC_LIB_DIR_PREFIXES is detected.

Fixes #701 