### PR TITLE
Reduce scan time by avoid having redundant file access

### DIFF
--- a/src/main/java/io/github/classgraph/ClasspathElementDir.java
+++ b/src/main/java/io/github/classgraph/ClasspathElementDir.java
@@ -111,17 +111,20 @@ class ClasspathElementDir extends ClasspathElement {
                 final Path libDirPath = classpathEltPath.resolve(libDirPrefix);
                 if (FileUtils.canReadAndIsDir(libDirPath)) {
                     // Add all jarfiles within the lib dir as child classpath entries
-                    try (DirectoryStream<Path> stream = Files.newDirectoryStream(libDirPath)) {
+                    try (DirectoryStream<Path> stream = Files.newDirectoryStream(libDirPath, new DirectoryStream.Filter<Path>() {
+                        @Override
+                        public boolean accept(Path filePath) {
+                            return filePath.toString().toLowerCase().endsWith(".jar") && Files.isRegularFile(filePath);
+                        }
+                    })) {
                         for (final Path filePath : stream) {
-                            if (Files.isRegularFile(filePath) && filePath.toString().toLowerCase().endsWith(".jar")) {
-                                if (log != null) {
-                                    log(classpathElementIdx, "Found lib jar: " + filePath, log);
-                                }
-                                workQueue.addWorkUnit(new ClasspathEntryWorkUnit(filePath, getClassLoader(),
-                                        /* parentClasspathElement = */ this,
-                                        /* orderWithinParentClasspathElement = */ childClasspathEntryIdx++,
-                                        /* packageRootPrefix = */ ""));
+                            if (log != null) {
+                                log(classpathElementIdx, "Found lib jar: " + filePath, log);
                             }
+                            workQueue.addWorkUnit(new ClasspathEntryWorkUnit(filePath, getClassLoader(),
+                                    /* parentClasspathElement = */ this,
+                                    /* orderWithinParentClasspathElement = */ childClasspathEntryIdx++,
+                                    /* packageRootPrefix = */ ""));
                         }
                     } catch (final IOException e) {
                         // Ignore -- thrown by Files.newDirectoryStream

--- a/src/main/java/nonapi/io/github/classgraph/fastzipfilereader/PhysicalZipFile.java
+++ b/src/main/java/nonapi/io/github/classgraph/fastzipfilereader/PhysicalZipFile.java
@@ -78,10 +78,6 @@ class PhysicalZipFile {
     PhysicalZipFile(final File file, final NestedJarHandler nestedJarHandler, final LogNode log)
             throws IOException {
         this.nestedJarHandler = nestedJarHandler;
-
-        // Make sure the File is readable and is a regular file
-        FileUtils.checkCanReadAndIsFile(file);
-
         this.file = file;
         this.pathStr = FastPathResolver.resolve(FileUtils.currDirPath(), file.getPath());
         this.slice = new FileSlice(file, nestedJarHandler, log);
@@ -102,10 +98,6 @@ class PhysicalZipFile {
     PhysicalZipFile(final Path path, final NestedJarHandler nestedJarHandler, final LogNode log)
             throws IOException {
         this.nestedJarHandler = nestedJarHandler;
-
-        // Make sure the File is readable and is a regular file
-        FileUtils.checkCanReadAndIsFile(path);
-
         this.path = path;
         this.pathStr = FastPathResolver.resolve(FileUtils.currDirPath(), path.toString());
         this.slice = new PathSlice(path, nestedJarHandler);

--- a/src/main/java/nonapi/io/github/classgraph/fileslice/PathSlice.java
+++ b/src/main/java/nonapi/io/github/classgraph/fileslice/PathSlice.java
@@ -112,10 +112,35 @@ public class PathSlice extends Slice {
      */
     public PathSlice(final Path path, final boolean isDeflatedZipEntry, final long inflatedLengthHint,
             final NestedJarHandler nestedJarHandler) throws IOException {
+        this(path, isDeflatedZipEntry, inflatedLengthHint, nestedJarHandler, true);
+    }
+
+    /**
+     * Constructor for toplevel file slice.
+     *
+     * @param path
+     *                           the path
+     * @param isDeflatedZipEntry
+     *                           true if this is a deflated zip entry
+     * @param inflatedLengthHint
+     *                           the uncompressed size of a deflated zip entry, or
+     *                           -1 if unknown, or 0 of this is not a deflated
+     *                           zip entry.
+     * @param nestedJarHandler
+     *                           the nested jar handler
+     * @param checkAccess
+     *                           whether it is needed to check read access and if it is a file
+     * @throws IOException
+     *                     if the file cannot be opened.
+     */
+    public PathSlice(final Path path, final boolean isDeflatedZipEntry, final long inflatedLengthHint,
+            final NestedJarHandler nestedJarHandler, boolean checkAccess) throws IOException {
         super(0L, isDeflatedZipEntry, inflatedLengthHint, nestedJarHandler);
 
-        // Make sure the File is readable and is a regular file
-        FileUtils.checkCanReadAndIsFile(path);
+        if (checkAccess) {
+            // Make sure the File is readable and is a regular file
+            FileUtils.checkCanReadAndIsFile(path);
+        }
 
         this.path = path;
         this.fileChannel = FileChannel.open(path, StandardOpenOption.READ);

--- a/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
+++ b/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
@@ -301,6 +301,10 @@ public final class FileUtils {
      */
     public static boolean canRead(final Path path) {
         try {
+            return canRead(path.toFile());
+        } catch (UnsupportedOperationException ignored) {
+        }
+        try {
             if (!Files.isReadable(path)) {
                 return false;
             }
@@ -336,6 +340,10 @@ public final class FileUtils {
      * @return true if the file exists, is a regular file, and can be read.
      */
     public static boolean canReadAndIsFile(final Path path) {
+        try {
+            return canReadAndIsFile(path.toFile());
+        } catch (UnsupportedOperationException ignored) {
+        }
         try {
             if (!Files.isReadable(path)) {
                 return false;
@@ -377,6 +385,11 @@ public final class FileUtils {
      */
     public static void checkCanReadAndIsFile(final Path path) throws IOException {
         try {
+            checkCanReadAndIsFile(path.toFile());
+            return;
+        } catch (UnsupportedOperationException ignored) {
+        }
+        try {
             if (!Files.isReadable(path)) {
                 throw new FileNotFoundException("Path does not exist or cannot be read: " + path);
             }
@@ -414,6 +427,10 @@ public final class FileUtils {
      * @return true if the file exists, is a directory, and can be read.
      */
     public static boolean canReadAndIsDir(final Path path) {
+        try {
+            return canReadAndIsDir(path.toFile());
+        } catch (UnsupportedOperationException ignored) {
+        }
         try {
             if (!Files.isReadable(path)) {
                 return false;

--- a/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
+++ b/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
@@ -305,13 +305,10 @@ public final class FileUtils {
         } catch (UnsupportedOperationException ignored) {
         }
         try {
-            if (!Files.isReadable(path)) {
-                return false;
-            }
+            return Files.isReadable(path);
         } catch (final SecurityException e) {
             return false;
         }
-        return Files.isRegularFile(path);
     }
 
     /**

--- a/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
+++ b/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
@@ -351,6 +351,16 @@ public final class FileUtils {
         return Files.isRegularFile(path);
     }
 
+    public static boolean isFile(final Path path) {
+        try {
+            return path.toFile().isFile();
+        } catch (UnsupportedOperationException e) {
+            return Files.isRegularFile(path);
+        } catch (SecurityException e) {
+            return false;
+        }
+    }
+
     /**
      * Check if a {@link File} exists, is a regular file, and can be read.
      *
@@ -436,6 +446,16 @@ public final class FileUtils {
             return false;
         }
         return Files.isDirectory(path);
+    }
+
+    public static boolean isDir(final Path path) {
+        try {
+            return path.toFile().isDirectory();
+        } catch (UnsupportedOperationException e) {
+            return Files.isDirectory(path);
+        } catch (SecurityException e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
These changes are meant to reduce the general file access and keep the same scan results as before.
Most of the time it is about removing some duplicated _canRead_, _isFile_ and similar calls that are usually top contibutors of the scanning time especially on Windows based systems with any kind of antivirus/firewall enabled.

I have tested these on a project using ~500 classpath entries, from which ~380 are jar files. Thanks to the extended ClassGraph configuration it was possible to filter out most of the artifacts that are not relevant, but even in that state it was a measurable improvement.
| | before | changes included |
|  :---: |  :---: | :---: |
| all | 21 s | 11 s  |
| filtered |  9 s | 6 s  |