### PR TITLE
Add a test for Issue 875

### DIFF
--- a/src/test/java/io/github/classgraph/issues/issue875/Issue875Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue875/Issue875Test.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of ClassGraph.
+ *
+ * Author: Luke Hutchison
+ *
+ * Hosted at: https://github.com/classgraph/classgraph
+ *
+ * --
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Luke Hutchison
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.classgraph.issues.issue875;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+/**
+ * Issue875Test.
+ */
+public class Issue875Test {
+    /**
+     * The Class SuperSuperCls.
+     */
+    private static class SuperSuperCls {
+    }
+
+    /**
+     * The Class SuperCls.
+     */
+    private static class SuperCls extends SuperSuperCls {
+    }
+
+    /**
+     * The Class Cls.
+     */
+    private static class Cls extends SuperCls {
+    }
+
+    /**
+     * Issue 875 test.
+     */
+    @Test
+    public void issue875Test() throws IOException {
+
+        Path path = Files.createTempFile("tmp", ".jar");
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(path))) {
+            Class<?> clazz = Cls.class;
+            String name = clazz.getName().replace('.', '/') + ".class";
+            jos.putNextEntry(new JarEntry(name));
+            InputStream is = clazz.getClassLoader().getResourceAsStream(name);
+            byte[] buffer = new byte[4096];
+            int length;
+            while ((length = is.read(buffer)) != -1) {
+                jos.write(buffer, 0, length);
+            }
+        }
+        URL url = path.toUri().toURL();
+        ClassLoader loader = new URLClassLoader(new URL[] {url});
+
+        // Accept only the class Cls, so that SuperCls and SuperSuperCls are external classes
+        try (ScanResult scanResult =
+                new ClassGraph()
+                        .enableRealtimeLogging()
+                        .addClassLoader(loader)
+                        .acceptPackagesNonRecursive("io.github.classgraph.issues.issue875")
+                        .ignoreParentClassLoaders()
+                        .enableExternalClasses()
+                        .enableAllInfo()
+                        .scan()) {
+            assertThat(scanResult.getSubclasses(SuperSuperCls.class).getNames())
+                    .containsOnly(SuperCls.class.getName(), Cls.class.getName());
+        }
+    }
+}


### PR DESCRIPTION
This may be working as intended. It looks like on JDK 9+, the scan is including `java.class.path`, I think because of the `moduleFinder != null && moduleFinder.forceScanJavaClassPath())` case here:

https://github.com/classgraph/classgraph/blob/8bfaa5776f22ca45ff8cc1c552d55510e754b2dd/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java#L299-L302

The test passes on JDK 11:

```
JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home/ ./mvnw test -Dtest=io.github.classgraph.issues.issue875.Issue875Test
...
INFO: 2024-07-26T10:03:31.542-0700  ClassGraph  Getting classpath entries from java.class.path
```

and fails on JDK 8

```
JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-8.jdk/Contents/Home/ ./mvnw test -Dtest=io.github.classgraph.issues.issue875.Issue875Test
...
INFO: 2024-07-26T10:02:23.108-0700  ClassGraph  External superclass io.github.classgraph.issues.issue875.Issue875Test$SuperCls was not found in non-rejected packages -- cannot extend scanning to this class
...
Expecting ArrayList:
  []
to contain only:
  ["io.github.classgraph.issues.issue875.Issue875Test$SuperCls",
    "io.github.classgraph.issues.issue875.Issue875Test$Cls"]
```