### PR TITLE
Store annotation getters of ClassInfo and MethodInfo

### DIFF
--- a/src/main/java/io/github/classgraph/ClassInfo.java
+++ b/src/main/java/io/github/classgraph/ClassInfo.java
@@ -179,6 +179,12 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
      */
     private transient List<ClassInfo> methodOverrideOrder;
 
+    /** The annotations, once they are loaded */
+    private ClassInfoList annotationsRef;
+
+    /** The annotation infos, once they are loaded */
+    private AnnotationInfoList annotationInfoRef;
+
     // -------------------------------------------------------------------------------------------------------------
 
     /** The modifier bit for annotations. */
@@ -1949,6 +1955,8 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
      * @return the list of annotations and meta-annotations on this class.
      */
     public ClassInfoList getAnnotations() {
+        if (annotationsRef != null) return annotationsRef;
+
         if (!scanResult.scanSpec.enableAnnotationInfo) {
             throw new IllegalArgumentException("Please call ClassGraph#enableAnnotationInfo() before #scan()");
         }
@@ -1975,13 +1983,14 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
 
         if (inheritedSuperclassAnnotations == null) {
             // No inherited superclass annotations
-            return new ClassInfoList(annotationClasses, /* sortByName = */ true);
+            annotationsRef = new ClassInfoList(annotationClasses, /* sortByName = */ true);
         } else {
             // Merge inherited superclass annotations and annotations on this class
             inheritedSuperclassAnnotations.addAll(annotationClasses.reachableClasses);
-            return new ClassInfoList(inheritedSuperclassAnnotations, annotationClasses.directlyRelatedClasses,
+            annotationsRef = new ClassInfoList(inheritedSuperclassAnnotations, annotationClasses.directlyRelatedClasses,
                     /* sortByName = */ true);
         }
+        return annotationsRef;
     }
 
     /**
@@ -2064,10 +2073,14 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
      *         none.
      */
     public AnnotationInfoList getAnnotationInfo() {
+        if (annotationInfoRef != null) return annotationInfoRef;
+
         if (!scanResult.scanSpec.enableAnnotationInfo) {
             throw new IllegalArgumentException("Please call ClassGraph#enableAnnotationInfo() before #scan()");
         }
-        return AnnotationInfoList.getIndirectAnnotations(annotationInfo, this);
+
+        annotationInfoRef = AnnotationInfoList.getIndirectAnnotations(annotationInfo, this);
+        return annotationInfoRef;
     }
 
     /**

--- a/src/main/java/io/github/classgraph/ClassMemberInfo.java
+++ b/src/main/java/io/github/classgraph/ClassMemberInfo.java
@@ -63,6 +63,9 @@ public abstract class ClassMemberInfo extends ScanResultObject implements HasNam
     /** The annotation on the class member, if any. */
     protected AnnotationInfoList annotationInfo;
 
+    /** The annotation infos, once they are loaded */
+    private AnnotationInfoList annotationInfoRef;
+
     /** Default constructor for deserialization. */
     ClassMemberInfo() {
         super();
@@ -283,11 +286,15 @@ public abstract class ClassMemberInfo extends ScanResultObject implements HasNam
      *         {@link AnnotationInfo} objects, or the empty list if none.
      */
     public AnnotationInfoList getAnnotationInfo() {
+        if (annotationInfoRef != null) return annotationInfoRef;
+
         if (!scanResult.scanSpec.enableAnnotationInfo) {
             throw new IllegalArgumentException("Please call ClassGraph#enableAnnotationInfo() before #scan()");
         }
-        return annotationInfo == null ? AnnotationInfoList.EMPTY_LIST
+
+        annotationInfoRef = annotationInfo == null ? AnnotationInfoList.EMPTY_LIST
                 : AnnotationInfoList.getIndirectAnnotations(annotationInfo, /* annotatedClass = */ null);
+        return annotationInfoRef;
     }
 
     /**


### PR DESCRIPTION
As those are the most likely used, this could save considerable CPU time

In my workload these changes produce a 2x improvement (~167ms -> ~84ms), as I run over some classes multiple times