### PR TITLE
Polish `QuarkusClassLoaderHandler` and `FastPathResolver`.

### DIFF
--- a/src/main/java/nonapi/io/github/classgraph/utils/FastPathResolver.java
+++ b/src/main/java/nonapi/io/github/classgraph/utils/FastPathResolver.java
@@ -43,11 +43,8 @@ public final class FastPathResolver {
     /** Match %-encoded characters in URLs. */
     private static final Pattern percentMatcher = Pattern.compile("([%][0-9a-fA-F][0-9a-fA-F])+");
 
-    /** Match custom URLs that are followed by two slashes. */
-    private static final Pattern schemeTwoSlashMatcher = Pattern.compile("^[a-zA-Z+\\-.]+://");
-
-    /** Match custom URLs that are followed by one slash. */
-    private static final Pattern schemeOneSlashMatcher = Pattern.compile("^[a-zA-Z+\\-.]+:/");
+    /** Match custom URLs that are followed by one or two slashes. */
+    private static final Pattern schemeOneOrTwoSlashMatcher = Pattern.compile("^[a-zA-Z+\\-.]+:/{1,2}");
 
     /**
      * Constructor.
@@ -236,24 +233,15 @@ public final class FastPathResolver {
             } else {
                 // Preserve the number of slashes on custom URL schemes (#420)
                 final String relPath = startIdx == 0 ? relativePath : relativePath.substring(startIdx);
-                final Matcher m2 = schemeTwoSlashMatcher.matcher(relPath);
-                if (m2.find()) {
+                final Matcher matcher = schemeOneOrTwoSlashMatcher.matcher(relPath);
+                if (matcher.find()) {
                     matchedPrefix = true;
-                    final String m2Match = m2.group();
-                    startIdx += m2Match.length();
-                    prefix += m2Match;
+                    final String match = matcher.group();
+                    startIdx += match.length();
+                    prefix += match;
                     // Treat the part after the protocol as an absolute path, so the rest of the URL is not treated
                     // as a directory relative to the current directory.
                     isAbsolutePath = true;
-                } else {
-                    final Matcher m1 = schemeOneSlashMatcher.matcher(relPath);
-                    if (m1.find()) {
-                        matchedPrefix = true;
-                        final String m1Match = m1.group();
-                        startIdx += m1Match.length();
-                        prefix += m1Match;
-                        isAbsolutePath = true;
-                    }
                 }
             }
         } while (matchedPrefix);


### PR DESCRIPTION
This is a follow up on issue #891 and the preceding PR #893 and brings two changes:

* The `QuarkusClassLoaderHandler` is a bit more explicit now about how the elements returned from the class loader are treated
* The `FastPathResolver` can be simplified using only one pattern

The latter was discovered while trying to get the custom URL scheme `quarkus:` that the Quarkus class loader uses for in-memory classes to work.

Ultimately, the work on using those in-memory classes, that are usually transformed classes such as session proxies, has been abandoned due to the fact that the current ClassGraph infrastructure can basically deal only with Jar and related entries, or directories.
To make the Quarkus in-memory classes work one would need to map them to ultimately into a Jar file and use an additional custom URL scheme, to "download" them again.
The alternative is additional implementations of `ClasspathElement`, but that would require a change on public API and this not only quite a bit out of my comfort zone, but also in all probability, not worth the effort.

I am happy to pick it if there's ever be a need, though.

The changes I had in addition (but those are only barely minimum, they won't work, as the scanner thinks that the urls are paths and does not use `openStream` or similar):

```java
    private static void findClasspathOrderForQuarkusClassloader(final ClassLoader classLoader,
                                                                final ClasspathOrder classpathOrder, final ScanSpec scanSpec, final LogNode log) {

        Collection<Object> elements = findQuarkusClassLoaderElements(classLoader, classpathOrder);

        for (final Object element : elements) {
            final String elementClassName = element.getClass().getName();
            final String fieldName = PRE_311_RESOURCE_BASED_ELEMENTS.get(elementClassName);
            if (fieldName != null) {
                classpathOrder.addClasspathEntry(classpathOrder.reflectionUtils.getFieldVal(false, element, fieldName),
                        classLoader, scanSpec, log);
            } else if("io.quarkus.bootstrap.classloading.MemoryClassPathElement".equals(elementClassName)) {
               handleInMemoryClassPathElements(classLoader, classpathOrder, scanSpec, log, element);
            } else {
                final Object rootPath = classpathOrder.reflectionUtils.invokeMethod(false, element, "getRoot");
                if (rootPath instanceof Path) {
                    classpathOrder.addClasspathEntry(rootPath, classLoader, scanSpec, log);
                }
            }
        }
    }

    @SuppressWarnings("unchecked")
    private static void handleInMemoryClassPathElements(final ClassLoader classLoader,
                                                        final ClasspathOrder classpathOrder, final ScanSpec scanSpec, final LogNode log, Object element) {
        // Those will be transformed classes, such as session proxies etc.
        Collection<String> resourceNames = (Collection<String>) classpathOrder.reflectionUtils.invokeMethod(false, element, "getProvidedResources");
        if (resourceNames == null) {
            return;
        }
        for (String resourceName : resourceNames) {
            Object resource = classpathOrder.reflectionUtils.invokeMethod(false, element, "getResource", String.class, resourceName);
            if (resource == null) {
                continue;
            }
            URL url = (URL) classpathOrder.reflectionUtils.invokeMethod(false, resource, "getUrl");
            classpathOrder.addClasspathEntryObject(url, classLoader, scanSpec, log);
        }
    }
```
