### PR TITLE
Update comment to specify that bootstrap class loader is used instead of context classloader

### DIFF
--- a/src/main/java/io/github/classgraph/ClassGraphClassLoader.java
+++ b/src/main/java/io/github/classgraph/ClassGraphClassLoader.java
@@ -89,8 +89,7 @@ public class ClassGraphClassLoader extends ClassLoader {
 
         // Only try environment classloaders if classpath and/or classloaders are not overridden
         if (!classpathOverridden && !classloadersOverridden) {
-            // Try the null classloader first (this will default to the context classloader of the class
-            // that called ClassGraph)
+            // Try the null classloader first (this will default to the bootstrap class loader)
             environmentClassLoaderDelegationOrder = new LinkedHashSet<>();
             environmentClassLoaderDelegationOrder.add(null);
 


### PR DESCRIPTION
The previous comment is inaccurate as the context classloader may have been modified. Instead, the comment should specify that bootstrap class loader is used

> If the parameter loader is null, the class is loaded through the bootstrap class loader

https://docs.oracle.com/javase/7/docs/api/java/lang/Class.html#forName(java.lang.String,%20boolean,%20java.lang.ClassLoader)





