### PR TITLE
feat(scan): propagate ScanResult to `ModuleInfo` and `PackageInfo` annotations

### DIFF
--- a/src/main/java/io/github/classgraph/ModuleInfo.java
+++ b/src/main/java/io/github/classgraph/ModuleInfo.java
@@ -217,6 +217,14 @@ public class ModuleInfo implements Comparable<ModuleInfo>, HasName {
 
     // -------------------------------------------------------------------------------------------------------------
 
+    void setScanResult(final ScanResult scanResult) {
+      if (annotationInfoSet != null) {
+        for (final AnnotationInfo ai : annotationInfoSet) {
+          ai.setScanResult(scanResult);
+        }
+      }
+    }
+
     /**
      * Add annotations found in a module descriptor classfile.
      *

--- a/src/main/java/io/github/classgraph/PackageInfo.java
+++ b/src/main/java/io/github/classgraph/PackageInfo.java
@@ -124,6 +124,14 @@ public class PackageInfo implements Comparable<PackageInfo>, HasName {
 
     // -------------------------------------------------------------------------------------------------------------
 
+    void setScanResult(final ScanResult scanResult) {
+        if (annotationInfoSet != null) {
+            for (final AnnotationInfo ai : annotationInfoSet) {
+                ai.setScanResult(scanResult);
+            }
+        }
+    }
+
     /**
      * Get a the annotation on this package, or null if the package does not have the annotation.
      * 

--- a/src/main/java/io/github/classgraph/ScanResult.java
+++ b/src/main/java/io/github/classgraph/ScanResult.java
@@ -352,6 +352,16 @@ public final class ScanResult implements Closeable {
                 ci.setReferencedClasses(new ClassInfoList(refdClassesFiltered, /* sortByName = */ true));
             }
         }
+
+        if (scanSpec.enableClassInfo) {
+          for (final PackageInfo pkgInfo : packageNameToPackageInfo.values()) {
+              pkgInfo.setScanResult(this);
+          }
+
+          for (final ModuleInfo moduleInfo : moduleNameToModuleInfo.values()) {
+              moduleInfo.setScanResult(this);
+          }
+        }
     }
 
     // -------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Introduce `setScanResult` methods in `ModuleInfo` and `PackageInfo` to assign `ScanResult` context to their associated annotations. This enables annotations to access scanning metadata when class info is enabled. Called from `ScanResult` during post-processing.