### PR TITLE
[Issue 920] Updating getMethodInfo to not get superconstructors

### DIFF
--- a/src/main/java/io/github/classgraph/ClassInfo.java
+++ b/src/main/java/io/github/classgraph/ClassInfo.java
@@ -2332,11 +2332,13 @@ public class ClassInfo extends ScanResultObject implements Comparable<ClassInfo>
         final MethodInfoList methodInfoList = new MethodInfoList();
         final Set<Entry<String, String>> nameAndTypeDescriptorSet = new HashSet<>();
         for (final ClassInfo ci : getMethodOverrideOrder()) {
-            for (final MethodInfo mi : ci.getDeclaredMethodInfo(methodName, getNormalMethods, getConstructorMethods,
+            // Constructors are not inherited from superclasses
+            boolean shouldGetConstructorMethods = ci == this && getConstructorMethods;
+            for (final MethodInfo mi : ci.getDeclaredMethodInfo(methodName, getNormalMethods, shouldGetConstructorMethods,
                     getStaticInitializerMethods)) {
-                // If method/constructor has not been overridden by method of same name and type descriptor 
+                // If method has not been overridden by method of same name and type descriptor
                 if (nameAndTypeDescriptorSet.add(new SimpleEntry<>(mi.getName(), mi.getTypeDescriptorStr()))) {
-                    // Add method/constructor to output order
+                    // Add method to output order
                     methodInfoList.add(mi);
                 }
             }

--- a/src/test/java/io/github/classgraph/issues/issue920/Issue920Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue920/Issue920Test.java
@@ -1,0 +1,35 @@
+package io.github.classgraph.issues.issue920;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.MethodInfo;
+import io.github.classgraph.MethodInfoList;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * ClassGraph used to return incorrect modifiers for non-public constructors if
+ * there is a public constructor of same signature in the superclass AND `ignoreMethodVisibility` has not been set.
+ * In that case it will instead return the super's constructor's modifiers.
+ */
+public class Issue920Test {
+    @Test
+    void test() {
+        MethodInfoList constructors = new ClassGraph()
+                .enableAnnotationInfo()
+                .enableSystemJarsAndModules()
+                .enableClassInfo()
+                .enableMethodInfo()
+                .scan()
+                .getClassInfo("java.io.ObjectOutputStream")
+                .getConstructorInfo();
+        for (MethodInfo constructor : constructors) {
+            if (constructor.getParameterInfo().length == 0) {
+                // The no args constructor of ObjectOutputStream is protected
+                assertEquals(Modifier.PROTECTED, constructor.getModifiers(), "The no-args constructor of ObjectOutputStream should read as `protected`");
+            }
+        }
+    }
+}


### PR DESCRIPTION
ClassGraph returns the MethodInfo of some (but not all!) superclass constructors when asked for a Class's constructors.

Particularly confusing for users if there's a non-public constructor with the same signature as a constructor in the superclass and `.ignoreMethodVisibility()` isn't set. This is the only case where an overridden method is returned from `getMethodInfo()` and is because constructors are the only case where a method can have the same signature as a superclass method, but have lower visibility.

[Issue link](https://github.com/classgraph/classgraph/issues/920)