### PR TITLE
`ClassLoaderHandler`: Use interface instead of reflection

### DIFF
--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/AntClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/AntClassLoaderHandler.java
@@ -36,54 +36,21 @@ import nonapi.io.github.classgraph.utils.LogNode;
 
 /** Extract classpath entries from the Ant ClassLoader. */
 class AntClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private AntClassLoaderHandler() {
-    }
 
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.apache.tools.ant.AntClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         classpathOrder.addClasspathPathStr(
                 (String) classpathOrder.reflectionUtils.invokeMethod(false, classLoader, "getClasspath"),
                 classLoader, scanSpec, log);

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/ClassGraphClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/ClassGraphClassLoaderHandler.java
@@ -42,20 +42,8 @@ import nonapi.io.github.classgraph.utils.LogNode;
  * share a single classloader (#485).
  */
 class ClassGraphClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private ClassGraphClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         final boolean matches = ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "io.github.classgraph.ClassGraphClassLoader");
         if (matches && log != null) {
@@ -66,36 +54,14 @@ class ClassGraphClassLoaderHandler implements ClassLoaderHandler {
         return matches;
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         // ClassGraphClassLoader overrides URLClassLoader, so we can get the basic classpath URLs the same
         // way as for URLClassLoader. However, classloading will try to preferentially reuse the older
         // ClassGraphClassLoader before loading with the new ClassGraphClassLoader from the current scan,

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/ClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/ClassLoaderHandler.java
@@ -28,11 +28,52 @@
  */
 package nonapi.io.github.classgraph.classloaderhandler;
 
+import nonapi.io.github.classgraph.classpath.ClassLoaderOrder;
+import nonapi.io.github.classgraph.classpath.ClasspathOrder;
+import nonapi.io.github.classgraph.scanspec.ScanSpec;
+import nonapi.io.github.classgraph.utils.LogNode;
+
 /**
  * A ClassLoader handler.
  * 
  * <p>
  * If you create a custom ClassLoaderHandler, please consider submitting it to the ClassGraph open source project.
  */
-public interface ClassLoaderHandler {
+interface ClassLoaderHandler {
+    /**
+     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
+     *
+     * @param classLoaderClass
+     *            the {@link ClassLoader} class or one of its superclasses.
+     * @param log
+     *            the log
+     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
+     */
+    boolean canHandle(Class<?> classLoaderClass, LogNode log);
+
+    /**
+     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
+     *
+     * @param classLoader
+     *            the {@link ClassLoader} to find the order for.
+     * @param classLoaderOrder
+     *            a {@link ClassLoaderOrder} object to update.
+     * @param log
+     *            the log
+     */
+    void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log);
+
+    /**
+     * Find the classpath entries for the associated {@link ClassLoader}.
+     *
+     * @param classLoader
+     *            the {@link ClassLoader} to find the classpath entries order for.
+     * @param classpathOrder
+     *            a {@link ClasspathOrder} object to update.
+     * @param scanSpec
+     *            the {@link ScanSpec}.
+     * @param log
+     *            the log.
+     */
+    void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log);
 }

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/ClassLoaderHandlerRegistry.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/ClassLoaderHandlerRegistry.java
@@ -28,7 +28,6 @@
  */
 package nonapi.io.github.classgraph.classloaderhandler;
 
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -47,41 +46,41 @@ public class ClassLoaderHandlerRegistry {
     public static final List<ClassLoaderHandlerRegistryEntry> CLASS_LOADER_HANDLERS = //
             Collections.unmodifiableList(Arrays.asList(
                     // ClassLoaderHandlers for other ClassLoaders that are handled by ClassGraph
-                    new ClassLoaderHandlerRegistryEntry(AntClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(EquinoxClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(EquinoxContextFinderClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(FelixClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(JBossClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(WeblogicClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(WebsphereLibertyClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(WebsphereTraditionalClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(OSGiDefaultClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(SpringBootRestartClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(TomcatWebappClassLoaderBaseHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(CxfContainerClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(PlexusClassWorldsClassRealmClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(QuarkusClassLoaderHandler.class),
-                    new ClassLoaderHandlerRegistryEntry(UnoOneJarClassLoaderHandler.class),
+                    new ClassLoaderHandlerRegistryEntry(new AntClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new EquinoxClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new EquinoxContextFinderClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new FelixClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new JBossClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new WeblogicClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new WebsphereLibertyClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new WebsphereTraditionalClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new OSGiDefaultClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new SpringBootRestartClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new TomcatWebappClassLoaderBaseHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new CxfContainerClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new PlexusClassWorldsClassRealmClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new QuarkusClassLoaderHandler()),
+                    new ClassLoaderHandlerRegistryEntry(new UnoOneJarClassLoaderHandler()),
 
                     // For unit testing of PARENT_LAST delegation order
-                    new ClassLoaderHandlerRegistryEntry(ParentLastDelegationOrderTestClassLoaderHandler.class),
+                    new ClassLoaderHandlerRegistryEntry(new ParentLastDelegationOrderTestClassLoaderHandler()),
 
                     // JPMS support (this handler does nothing, since modules are handled separately)
-                    new ClassLoaderHandlerRegistryEntry(JPMSClassLoaderHandler.class),
+                    new ClassLoaderHandlerRegistryEntry(new JPMSClassLoaderHandler()),
 
                     // Java 7/8 URLClassLoader support (should be second-to-last, so that subclasses of
                     // URLClassLoader are handled by more specific handlers above)
-                    new ClassLoaderHandlerRegistryEntry(URLClassLoaderHandler.class),
+                    new ClassLoaderHandlerRegistryEntry(new URLClassLoaderHandler()),
 
                     // Placeholder for delegation to a ClassGraphClassLoader instance from an outer nested scan
-                    new ClassLoaderHandlerRegistryEntry(ClassGraphClassLoaderHandler.class)
+                    new ClassLoaderHandlerRegistryEntry(new ClassGraphClassLoaderHandler())
 
             // FallbackClassLoaderHandler.class is registered separately below
             ));
 
     /** Fallback ClassLoaderHandler. */
     public static final ClassLoaderHandlerRegistryEntry FALLBACK_HANDLER = new ClassLoaderHandlerRegistryEntry(
-            FallbackClassLoaderHandler.class);
+            new FallbackClassLoaderHandler());
 
     // -------------------------------------------------------------------------------------------------------------
 
@@ -132,50 +131,20 @@ public class ClassLoaderHandlerRegistry {
      * A list of fully-qualified ClassLoader class names paired with the ClassLoaderHandler that can handle them.
      */
     public static class ClassLoaderHandlerRegistryEntry {
-        /** canHandle method. */
-        private final Method canHandleMethod;
-
-        /** findClassLoaderOrder method. */
-        private final Method findClassLoaderOrderMethod;
-
-        /** findClasspathOrder method. */
-        private final Method findClasspathOrderMethod;
-
-        /** The ClassLoaderHandler class. */
-        public final Class<? extends ClassLoaderHandler> classLoaderHandlerClass;
+        public final ClassLoaderHandler classLoaderHandler;
 
         /**
          * Constructor.
          *
-         * @param classLoaderHandlerClass
+         * @param classLoaderHandler
          *            The ClassLoaderHandler class.
          */
-        private ClassLoaderHandlerRegistryEntry(final Class<? extends ClassLoaderHandler> classLoaderHandlerClass) {
-            // TODO: replace these with MethodHandles for speed
-            // TODO: (although MethodHandles are disabled for now, due to Animal Sniffer bug):
-            // https://github.com/mojohaus/animal-sniffer/issues/67
-            this.classLoaderHandlerClass = classLoaderHandlerClass;
-            try {
-                canHandleMethod = classLoaderHandlerClass.getDeclaredMethod("canHandle", Class.class,
-                        LogNode.class);
-            } catch (final Exception e) {
-                throw new RuntimeException(
-                        "Could not find canHandle method for " + classLoaderHandlerClass.getName(), e);
-            }
-            try {
-                findClassLoaderOrderMethod = classLoaderHandlerClass.getDeclaredMethod("findClassLoaderOrder",
-                        ClassLoader.class, ClassLoaderOrder.class, LogNode.class);
-            } catch (final Exception e) {
-                throw new RuntimeException(
-                        "Could not find findClassLoaderOrder method for " + classLoaderHandlerClass.getName(), e);
-            }
-            try {
-                findClasspathOrderMethod = classLoaderHandlerClass.getDeclaredMethod("findClasspathOrder",
-                        ClassLoader.class, ClasspathOrder.class, ScanSpec.class, LogNode.class);
-            } catch (final Exception e) {
-                throw new RuntimeException(
-                        "Could not find findClasspathOrder method for " + classLoaderHandlerClass.getName(), e);
-            }
+        private ClassLoaderHandlerRegistryEntry(ClassLoaderHandler classLoaderHandler) {
+            this.classLoaderHandler = classLoaderHandler;
+        }
+
+        public String getHandlerName() {
+            return classLoaderHandler.getClass().getName();
         }
 
         /**
@@ -188,12 +157,7 @@ public class ClassLoaderHandlerRegistry {
          * @return true, if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
          */
         public boolean canHandle(final Class<?> classLoader, final LogNode log) {
-            try {
-                return (boolean) canHandleMethod.invoke(null, classLoader, log);
-            } catch (final Throwable e) {
-                throw new RuntimeException(
-                        "Exception while calling canHandle for " + classLoaderHandlerClass.getName(), e);
-            }
+            return classLoaderHandler.canHandle(classLoader, log);
         }
 
         /**
@@ -209,12 +173,7 @@ public class ClassLoaderHandlerRegistry {
          */
         public void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
                 final LogNode log) {
-            try {
-                findClassLoaderOrderMethod.invoke(null, classLoader, classLoaderOrder, log);
-            } catch (final Throwable e) {
-                throw new RuntimeException(
-                        "Exception while calling findClassLoaderOrder for " + classLoaderHandlerClass.getName(), e);
-            }
+            classLoaderHandler.findClassLoaderOrder(classLoader, classLoaderOrder, log);
         }
 
         /**
@@ -232,12 +191,7 @@ public class ClassLoaderHandlerRegistry {
          */
         public void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
                 final ScanSpec scanSpec, final LogNode log) {
-            try {
-                findClasspathOrderMethod.invoke(null, classLoader, classpathOrder, scanSpec, log);
-            } catch (final Throwable e) {
-                throw new RuntimeException(
-                        "Exception while calling findClassLoaderOrder for " + classLoaderHandlerClass.getName(), e);
-            }
+            classLoaderHandler.findClasspathOrder(classLoader, classpathOrder, scanSpec, log);
         }
     }
 }

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/CxfContainerClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/CxfContainerClassLoaderHandler.java
@@ -36,36 +36,14 @@ import nonapi.io.github.classgraph.utils.LogNode;
 
 /** ClassLoaderHandler that is able to extract the URLs from a CxfContainerClassLoader. */
 class CxfContainerClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private CxfContainerClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.apache.openejb.server.cxf.transport.util.CxfContainerClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         try {
             classLoaderOrder.delegateTo(
                     Class.forName("org.apache.openejb.server.cxf.transport.util.CxfUtil").getClassLoader(),
@@ -81,20 +59,8 @@ class CxfContainerClassLoaderHandler implements ClassLoaderHandler {
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         // Classloader doesn't do any classloading of its own, it only delegates to other classloaders
     }
 }

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/EquinoxClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/EquinoxClassLoaderHandler.java
@@ -51,36 +51,14 @@ class EquinoxClassLoaderHandler implements ClassLoaderHandler {
     /** Field names. */
     private static final String[] FIELD_NAMES = { "cp", "nestedDirName" };
 
-    /** Class cannot be constructed. */
-    private EquinoxClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.eclipse.osgi.internal.loader.EquinoxClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
@@ -176,20 +154,8 @@ class EquinoxClassLoaderHandler implements ClassLoaderHandler {
         }
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         // type ClasspathManager
         final Object manager = classpathOrder.reflectionUtils.getFieldVal(false, classLoader, "manager");
         addClasspathEntries(manager, classLoader, classpathOrder, scanSpec, log);

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/EquinoxContextFinderClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/EquinoxContextFinderClassLoaderHandler.java
@@ -36,56 +36,22 @@ import nonapi.io.github.classgraph.utils.LogNode;
 
 /** Extract classpath entries from the Eclipse Equinox ContextFinder ClassLoader. */
 class EquinoxContextFinderClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private EquinoxContextFinderClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.eclipse.osgi.internal.framework.ContextFinder");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo((ClassLoader) classLoaderOrder.reflectionUtils.getFieldVal(false, classLoader,
                 "parentContextClassLoader"), /* isParent = */ true, log);
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         // Nothing to handle -- embedded parentContextClassLoader will be used instead.
     }
 }

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/FallbackClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/FallbackClassLoaderHandler.java
@@ -37,54 +37,20 @@ import nonapi.io.github.classgraph.utils.LogNode;
  * Fallback ClassLoaderHandler. Tries to get classpath from a range of possible method and field names.
  */
 class FallbackClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private FallbackClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         // This is the fallback handler, it handles anything
         return true;
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         boolean valid = false;
         valid |= classpathOrder.addClasspathEntryObject(
                 classpathOrder.reflectionUtils.invokeMethod(false, classLoader, "getClassPath"), classLoader,

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/FelixClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/FelixClassLoaderHandler.java
@@ -49,38 +49,16 @@ import nonapi.io.github.classgraph.utils.LogNode;
  * @author elrufaie
  */
 class FelixClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private FelixClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.apache.felix.framework.BundleWiringImpl$BundleClassLoaderJava5")
                 || ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                         "org.apache.felix.framework.BundleWiringImpl$BundleClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
@@ -146,20 +124,8 @@ class FelixClassLoaderHandler implements ClassLoaderHandler {
         }
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         // Get the wiring for the ClassLoader's bundle
         final Set<Object> bundles = new HashSet<>();
         final Object bundleWiring = classpathOrder.reflectionUtils.getFieldVal(false, classLoader, "m_wiring");

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/JBossClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/JBossClassLoaderHandler.java
@@ -52,36 +52,14 @@ import nonapi.io.github.classgraph.utils.LogNode;
  * https://github.com/jboss-modules/jboss-modules/blob/master/src/main/java/org/jboss/modules/ModuleClassLoader.java
  */
 class JBossClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private JBossClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.jboss.modules.ModuleClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
@@ -289,20 +267,8 @@ class JBossClassLoaderHandler implements ClassLoaderHandler {
         }
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         final Object module = classpathOrder.reflectionUtils.invokeMethod(false, classLoader, "getModule");
         final Object callerModuleLoader = classpathOrder.reflectionUtils.invokeMethod(false, module,
                 "getCallerModuleLoader");

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/JPMSClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/JPMSClassLoaderHandler.java
@@ -41,56 +41,22 @@ import nonapi.io.github.classgraph.utils.LogNode;
  * them (module scanning uses a different mechanism from classpath scanning).
  */
 class JPMSClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private JPMSClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "jdk.internal.loader.ClassLoaders$AppClassLoader")
                 || ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                         "jdk.internal.loader.BuiltinClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         // The JDK9 classloaders have a field, `URLClassPath ucp`, containing URLs for unnamed modules,
         // but it is not visible. Modules therefore have to be scanned using the JPMS API.
         // However, it is possible for a Java agent to extend UCP by adding directly to the `ucp` field

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/OSGiDefaultClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/OSGiDefaultClassLoaderHandler.java
@@ -42,54 +42,20 @@ import nonapi.io.github.classgraph.utils.LogNode;
  * @author lukehutch
  */
 class OSGiDefaultClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private OSGiDefaultClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.eclipse.osgi.internal.baseadaptor.DefaultClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         final Object classpathManager = classpathOrder.reflectionUtils.invokeMethod(false, classLoader,
                 "getClasspathManager");
         final Object[] entries = (Object[]) classpathOrder.reflectionUtils.getFieldVal(false, classpathManager,

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/ParentLastDelegationOrderTestClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/ParentLastDelegationOrderTestClassLoaderHandler.java
@@ -36,55 +36,21 @@ import nonapi.io.github.classgraph.utils.LogNode;
 
 /** ClassLoaderHandler that is used to test PARENT_LAST delegation order. */
 class ParentLastDelegationOrderTestClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private ParentLastDelegationOrderTestClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "io.github.classgraph.issues.issue267.FakeRestartClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         // Add self first, then delegate to parent
         classLoaderOrder.add(classLoader, log);
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         final String classpath = (String) classpathOrder.reflectionUtils.invokeMethod(/* throwException = */ true,
                 classLoader, "getClasspath");
         classpathOrder.addClasspathEntry(classpath, classLoader, scanSpec, log);

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/PlexusClassWorldsClassRealmClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/PlexusClassWorldsClassRealmClassLoaderHandler.java
@@ -42,21 +42,9 @@ import nonapi.io.github.classgraph.utils.LogNode;
  * 
  * @author lukehutch
  */
-class PlexusClassWorldsClassRealmClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private PlexusClassWorldsClassRealmClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+class PlexusClassWorldsClassRealmClassLoaderHandler extends URLClassLoaderHandler {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.codehaus.plexus.classworlds.realm.ClassRealm");
     }
@@ -83,20 +71,10 @@ class PlexusClassWorldsClassRealmClassLoaderHandler implements ClassLoaderHandle
         return true;
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classRealm
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classRealm, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         // From ClassRealm#loadClassFromImport(String) -> getImportClassLoader(String)
-        final Object foreignImports = classLoaderOrder.reflectionUtils.getFieldVal(false, classRealm,
+        final Object foreignImports = classLoaderOrder.reflectionUtils.getFieldVal(false, classLoader,
                 "foreignImports");
         if (foreignImports != null) {
             @SuppressWarnings("unchecked")
@@ -110,44 +88,32 @@ class PlexusClassWorldsClassRealmClassLoaderHandler implements ClassLoaderHandle
         }
 
         // Get delegation order -- different strategies have different delegation orders
-        final boolean isParentFirst = isParentFirstStrategy(classRealm, classLoaderOrder.reflectionUtils);
+        final boolean isParentFirst = isParentFirstStrategy(classLoader, classLoaderOrder.reflectionUtils);
 
         // From ClassRealm#loadClassFromSelf(String) -> findLoadedClass(String) for self-first strategy
         if (!isParentFirst) {
             // Add self before parent
-            classLoaderOrder.add(classRealm, log);
+            classLoaderOrder.add(classLoader, log);
         }
 
         // From ClassRealm#loadClassFromParent -- N.B. we are ignoring parentImports, which is used to filter
         // a class name before deciding whether or not to call the parent classloader (so ClassGraph will be
         // able to load classes by name that are not imported from the parent classloader).
         final ClassLoader parentClassLoader = (ClassLoader) classLoaderOrder.reflectionUtils.invokeMethod(false,
-                classRealm, "getParentClassLoader");
+                classLoader, "getParentClassLoader");
         classLoaderOrder.delegateTo(parentClassLoader, /* isParent = */ true, log);
-        classLoaderOrder.delegateTo(classRealm.getParent(), /* isParent = */ true, log);
+        classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
 
         // From ClassRealm#loadClassFromSelf(String) -> findLoadedClass(String) for parent-first strategy
         if (isParentFirst) {
             // Add self after parent
-            classLoaderOrder.add(classRealm, log);
+            classLoaderOrder.add(classLoader, log);
         }
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         // ClassRealm extends URLClassLoader
-        URLClassLoaderHandler.findClasspathOrder(classLoader, classpathOrder, scanSpec, log);
+        super.findClasspathOrder(classLoader, classpathOrder, scanSpec, log);
     }
 }

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/QuarkusClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/QuarkusClassLoaderHandler.java
@@ -65,57 +65,21 @@ class QuarkusClassLoaderHandler implements ClassLoaderHandler {
         PRE_311_RESOURCE_BASED_ELEMENTS = Collections.unmodifiableMap(hlp);
     }
 
-    /**
-     * Class cannot be constructed.
-     */
-    private QuarkusClassLoaderHandler() {
-    }
-
-    /**
-     * Can handle.
-     *
-     * @param classLoaderClass
-     *            the classloader class
-     * @param log
-     *            the log
-     * @return true, if classLoaderClass is the Quarkus RuntimeClassloader or QuarkusClassloader
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass, RUNTIME_CLASSLOADER)
                 || ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass, QUARKUS_CLASSLOADER)
                 || ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass, RUNNER_CLASSLOADER);
     }
 
-    /**
-     * Find classloader order.
-     *
-     * @param classLoader
-     *            the class loader
-     * @param classLoaderOrder
-     *            the classloader order
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
 
         final String classLoaderName = classLoader.getClass().getName();
         if (RUNTIME_CLASSLOADER.equals(classLoaderName)) {

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/SpringBootRestartClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/SpringBootRestartClassLoaderHandler.java
@@ -42,36 +42,14 @@ import nonapi.io.github.classgraph.utils.LogNode;
  * handler for that class loader also has to delegate in <code>PARENT_LAST</code> order.
  */
 class SpringBootRestartClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private SpringBootRestartClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.springframework.boot.devtools.restart.classloader.RestartClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         // The Restart classloader is a parent-last classloader, so add the Restart classloader itself to the
         // classloader order first
         classLoaderOrder.add(classLoader, log);
@@ -103,8 +81,8 @@ class SpringBootRestartClassLoaderHandler implements ClassLoaderHandler {
      * @param log
      *            the log.
      */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         // The Restart classloader doesn't itself store any URLs
     }
 }

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/TomcatWebappClassLoaderBaseHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/TomcatWebappClassLoaderBaseHandler.java
@@ -40,20 +40,8 @@ import nonapi.io.github.classgraph.utils.LogNode;
 
 /** Extract classpath entries from the Tomcat/Catalina WebappClassLoaderBase. */
 class TomcatWebappClassLoaderBaseHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private TomcatWebappClassLoaderBaseHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "org.apache.catalina.loader.WebappClassLoaderBase");
     }
@@ -74,18 +62,8 @@ class TomcatWebappClassLoaderBaseHandler implements ClassLoaderHandler {
         return true;
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         final boolean isParentFirst = isParentFirst(classLoader, classLoaderOrder.reflectionUtils);
         if (isParentFirst) {
             // Use parent-first delegation order
@@ -109,20 +87,8 @@ class TomcatWebappClassLoaderBaseHandler implements ClassLoaderHandler {
         }
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         // type StandardRoot (implements WebResourceRoot)
         final Object resources = classpathOrder.reflectionUtils.invokeMethod(false, classLoader, "getResources");
         // type List<URL>

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/URLClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/URLClassLoaderHandler.java
@@ -39,53 +39,19 @@ import nonapi.io.github.classgraph.utils.LogNode;
 
 /** ClassLoaderHandler that is able to extract the URLs from a URLClassLoader. */
 class URLClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private URLClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass, "java.net.URLClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         final URL[] urls = ((URLClassLoader) classLoader).getURLs();
         if (urls != null) {
             for (final URL url : urls) {

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/UnoOneJarClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/UnoOneJarClassLoaderHandler.java
@@ -36,56 +36,22 @@ import nonapi.io.github.classgraph.utils.LogNode;
 
 /** Extract classpath entries from the Uno-Jar's JarClassLoader and One-Jar's JarClassLoader. */
 class UnoOneJarClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private UnoOneJarClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "com.needhamsoftware.unojar.JarClassLoader")
                 || ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                         "com.simontuffs.onejar.JarClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
 
         // For Uno-Jar:
 

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/WeblogicClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/WeblogicClassLoaderHandler.java
@@ -36,20 +36,8 @@ import nonapi.io.github.classgraph.utils.LogNode;
 
 /** Extract classpath entries from the Weblogic ClassLoaders. */
 class WeblogicClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private WeblogicClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "weblogic.utils.classloaders.ChangeAwareClassLoader")
                 || ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
@@ -64,36 +52,14 @@ class WeblogicClassLoaderHandler implements ClassLoaderHandler {
                         "weblogic.servlet.jsp.TagFileClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         classpathOrder.addClasspathPathStr( //
                 (String) classpathOrder.reflectionUtils.invokeMethod(false, classLoader, "getFinderClassPath"),
                 classLoader, scanSpec, log);

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/WebsphereLibertyClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/WebsphereLibertyClassLoaderHandler.java
@@ -62,37 +62,15 @@ class WebsphereLibertyClassLoaderHandler implements ClassLoaderHandler {
     /** {@code "com.ibm.ws.classloading.internal.ThreadContextClassLoader"} */
     private static final String IBM_THREAD_CONTEXT_CLASS_LOADER = PKG_PREFIX + "ThreadContextClassLoader";
 
-    /** Class cannot be constructed. */
-    private WebsphereLibertyClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass, IBM_APP_CLASS_LOADER)
                 || ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                         IBM_THREAD_CONTEXT_CLASS_LOADER);
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
@@ -202,20 +180,8 @@ class WebsphereLibertyClassLoaderHandler implements ClassLoaderHandler {
         return Collections.emptyList();
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         Object smartClassPath;
         final Object appLoader = classpathOrder.reflectionUtils.getFieldVal(false, classLoader, "appLoader");
         if (appLoader != null) {

--- a/src/main/java/nonapi/io/github/classgraph/classloaderhandler/WebsphereTraditionalClassLoaderHandler.java
+++ b/src/main/java/nonapi/io/github/classgraph/classloaderhandler/WebsphereTraditionalClassLoaderHandler.java
@@ -40,20 +40,8 @@ import nonapi.io.github.classgraph.utils.LogNode;
  * @author lukehutch
  */
 class WebsphereTraditionalClassLoaderHandler implements ClassLoaderHandler {
-    /** Class cannot be constructed. */
-    private WebsphereTraditionalClassLoaderHandler() {
-    }
-
-    /**
-     * Check whether this {@link ClassLoaderHandler} can handle a given {@link ClassLoader}.
-     *
-     * @param classLoaderClass
-     *            the {@link ClassLoader} class or one of its superclasses.
-     * @param log
-     *            the log
-     * @return true if this {@link ClassLoaderHandler} can handle the {@link ClassLoader}.
-     */
-    public static boolean canHandle(final Class<?> classLoaderClass, final LogNode log) {
+    @Override
+    public boolean canHandle(Class<?> classLoaderClass, LogNode log) {
         return ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
                 "com.ibm.ws.classloader.CompoundClassLoader")
                 || ClassLoaderFinder.classIsOrExtendsOrImplements(classLoaderClass,
@@ -62,36 +50,14 @@ class WebsphereTraditionalClassLoaderHandler implements ClassLoaderHandler {
                         "com.ibm.ws.bootstrap.ExtClassLoader");
     }
 
-    /**
-     * Find the {@link ClassLoader} delegation order for a {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the order for.
-     * @param classLoaderOrder
-     *            a {@link ClassLoaderOrder} object to update.
-     * @param log
-     *            the log
-     */
-    public static void findClassLoaderOrder(final ClassLoader classLoader, final ClassLoaderOrder classLoaderOrder,
-            final LogNode log) {
+    @Override
+    public void findClassLoaderOrder(ClassLoader classLoader, ClassLoaderOrder classLoaderOrder, LogNode log) {
         classLoaderOrder.delegateTo(classLoader.getParent(), /* isParent = */ true, log);
         classLoaderOrder.add(classLoader, log);
     }
 
-    /**
-     * Find the classpath entries for the associated {@link ClassLoader}.
-     *
-     * @param classLoader
-     *            the {@link ClassLoader} to find the classpath entries order for.
-     * @param classpathOrder
-     *            a {@link ClasspathOrder} object to update.
-     * @param scanSpec
-     *            the {@link ScanSpec}.
-     * @param log
-     *            the log.
-     */
-    public static void findClasspathOrder(final ClassLoader classLoader, final ClasspathOrder classpathOrder,
-            final ScanSpec scanSpec, final LogNode log) {
+    @Override
+    public void findClasspathOrder(ClassLoader classLoader, ClasspathOrder classpathOrder, ScanSpec scanSpec, LogNode log) {
         final String classpath = (String) classpathOrder.reflectionUtils.invokeMethod(false, classLoader,
                 "getClassPath");
         classpathOrder.addClasspathPathStr(classpath, classLoader, scanSpec, log);

--- a/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
+++ b/src/main/java/nonapi/io/github/classgraph/classpath/ClasspathFinder.java
@@ -238,7 +238,7 @@ public class ClasspathFinder {
                 final LogNode classLoaderHandlerLog = classpathFinderLog.log("ClassLoaderHandlers:");
                 for (final ClassLoaderHandlerRegistryEntry classLoaderHandlerEntry : //
                 ClassLoaderHandlerRegistry.CLASS_LOADER_HANDLERS) {
-                    classLoaderHandlerLog.log(classLoaderHandlerEntry.classLoaderHandlerClass.getName());
+                    classLoaderHandlerLog.log(classLoaderHandlerEntry.getHandlerName());
                 }
             }
 
@@ -273,14 +273,14 @@ public class ClasspathFinder {
                         final LogNode classloaderHandlerLog = classloaderURLLog == null ? null
                                 : classloaderURLLog.log("Classloader " + classLoader.getClass().getName()
                                         + " is handled by "
-                                        + classLoaderHandlerRegistryEntry.classLoaderHandlerClass.getName());
+                                        + classLoaderHandlerRegistryEntry.getHandlerName());
                         classLoaderHandlerRegistryEntry.findClasspathOrder(classLoader, classpathOrder, scanSpec,
                                 classloaderHandlerLog);
                         finalClassLoaderOrder.add(classLoader);
                     } else if (classloaderURLLog != null) {
                         classloaderURLLog
                                 .log("Ignoring parent classloader " + classLoader + ", normally handled by "
-                                        + classLoaderHandlerRegistryEntry.classLoaderHandlerClass.getName());
+                                        + classLoaderHandlerRegistryEntry.getHandlerName());
                     }
                     // See if a previous scan's ClassGraphClassLoader should be delegated to first
                     if (classLoader instanceof ClassGraphClassLoader) {


### PR DESCRIPTION
We've discussed it a bit in here https://github.com/classgraph/classgraph/issues/906#issuecomment-3027438679

It's not really a followup to the issue, I just figured I'd PR improvements like these as i've been looking to optimize my reflection code.

I haven't bothered using `ServiceLoader`, doesn't seem necessary right now.