### PR TITLE
Optimize and remember resolved/sanitized paths

### DIFF
--- a/src/main/java/io/github/classgraph/ClasspathElementDir.java
+++ b/src/main/java/io/github/classgraph/ClasspathElementDir.java
@@ -65,6 +65,8 @@ import nonapi.io.github.classgraph.utils.VersionFinder;
 
 /** A directory classpath element, using the {@link Path} API. */
 class ClasspathElementDir extends ClasspathElement {
+    private static final int NOT_YET_LOADED_LENGTH = -2;
+
     /** The directory at the root of the classpath element. */
     private final Path classpathEltPath;
 
@@ -166,8 +168,19 @@ class ClasspathElementDir extends ClasspathElement {
      * @return the resource
      */
     private Resource newResource(final Path resourcePath, final BasicFileAttributes attributes) {
-        final int notYetLoadedLength = -2;
-        return new Resource(this, attributes == null ? notYetLoadedLength : attributes.size()) {
+        String resolvedResourcePath = FastPathResolver.resolve(classpathEltPath.relativize(resourcePath).toString());
+        return newResourceWithResolvedPath(resourcePath, resolvedResourcePath, attributes);
+    }
+
+    private Resource newResourceWithResolvedPath(final Path resourcePath, String resolvedResourcePath, final BasicFileAttributes attributes) {
+        while (resolvedResourcePath.startsWith("/")) {
+            resolvedResourcePath = resolvedResourcePath.substring(1);
+        }
+        return newResource0(resourcePath, resolvedResourcePath, attributes);
+    }
+
+    private Resource newResource0(final Path resourcePath, final String resolvedResourcePath, final BasicFileAttributes attributes) {
+        return new Resource(this, attributes == null ? NOT_YET_LOADED_LENGTH : attributes.size()) {
             /** The {@link PathSlice} opened on the file. */
             private PathSlice pathSlice;
 
@@ -176,7 +189,7 @@ class ClasspathElementDir extends ClasspathElement {
 
             @Override
             public long getLength() {
-                if (length == notYetLoadedLength) {
+                if (length == NOT_YET_LOADED_LENGTH) {
                     try {
                         length = Files.size(resourcePath);
                     } catch (IOException | SecurityException e) {
@@ -188,11 +201,7 @@ class ClasspathElementDir extends ClasspathElement {
 
             @Override
             public String getPath() {
-                String path = FastPathResolver.resolve(classpathEltPath.relativize(resourcePath).toString());
-                while (path.startsWith("/")) {
-                    path = path.substring(1);
-                }
-                return path;
+                return resolvedResourcePath;
             }
 
             @Override
@@ -440,7 +449,7 @@ class ClasspathElementDir extends ClasspathElement {
                             || (parentMatchStatus == ScanSpecPathMatch.AT_ACCEPTED_CLASS_PACKAGE
                                     && scanSpec.classfileIsSpecificallyAccepted(subPathRelativeStr))) {
                         // Resource is accepted
-                        final Resource resource = newResource(subPath, fileAttributes);
+                        final Resource resource = newResourceWithResolvedPath(subPath, subPathRelativeStr, fileAttributes);
                         addAcceptedResource(resource, parentMatchStatus, /* isClassfileOnly = */ false, subLog);
 
                         // Save last modified time

--- a/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
+++ b/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
@@ -159,38 +159,22 @@ public final class FileUtils {
             return "";
         }
 
-        // Find all '/' and '!' character positions, which split a path into segments 
-        boolean foundSegmentToSanitize = false;
-        final int pathLen = path.length();
-        final char[] pathChars = new char[pathLen];
-        path.getChars(0, pathLen, pathChars, 0);
-        {
-            int lastSepIdx = -1;
-            char prevC = '\0';
-            for (int i = 0, ii = pathLen + 1; i < ii; i++) {
-                final char c = i == pathLen ? '\0' : pathChars[i];
-                if (c == '/' || c == '!' || c == '\0') {
-                    final int segmentLength = i - (lastSepIdx + 1);
-                    if (
-                    // Found empty segment "//" or "!!"
-                    (segmentLength == 0 && prevC == c)
-                            // Found segment "."
-                            || (segmentLength == 1 && pathChars[i - 1] == '.')
-                            // Found segment ".."
-                            || (segmentLength == 2 && pathChars[i - 2] == '.' && pathChars[i - 1] == '.')) {
-                        foundSegmentToSanitize = true;
-                    }
-                    lastSepIdx = i;
-                }
-                prevC = c;
-            }
-        }
+        // Sanitize when:
+        // - Segment is empty: /<nothing>/
+        // - Nested JAR path is empty: !<nothing>!
+        // - Segment is . (redundant)
+        // - Segment is .. (needs to be applied while considering boundaries)
+        boolean foundSegmentToSanitize = path.contains("//") || path.contains("!!")
+                // This implicitly takes care of detecting '..!' and '../'
+                || path.contains(".!") || path.contains("./");
 
         // Handle "..", "." and empty path segments, if any were found
-        final boolean pathHasInitialSlash = pathChars[0] == '/';
-        final boolean pathHasInitialSlashSlash = pathHasInitialSlash && pathLen > 1 && pathChars[1] == '/';
-        final StringBuilder pathSanitized = new StringBuilder(pathLen + 16);
+        final boolean pathHasInitialSlash = path.startsWith("/");
+        final boolean pathHasInitialSlashSlash = path.startsWith("//");
+        final StringBuilder pathSanitized = new StringBuilder(path.length() + 16);
         if (foundSegmentToSanitize) {
+            final int pathLen = path.length();
+            final char[] pathChars = path.toCharArray();
             // Sanitize between "!" section markers separately (".." should not apply past preceding "!")
             final List<List<CharSequence>> allSectionSegments = new ArrayList<>();
             List<CharSequence> currSectionSegments = new ArrayList<>();

--- a/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
+++ b/src/main/java/nonapi/io/github/classgraph/utils/FileUtils.java
@@ -77,7 +77,7 @@ public final class FileUtils {
     private static Object theUnsafe;
 
     /** True if class' static fields have been initialized. */
-    private static AtomicBoolean initialized = new AtomicBoolean();
+    private static final AtomicBoolean initialized = new AtomicBoolean();
 
     /**
      * The current directory path (only reads the current directory once, the first time this field is accessed, so
@@ -180,7 +180,7 @@ public final class FileUtils {
             List<CharSequence> currSectionSegments = new ArrayList<>();
             allSectionSegments.add(currSectionSegments);
             int lastSepIdx = -1;
-            for (int i = 0; i < pathLen + 1; i++) {
+            for (int i = 0; i <= pathLen; i++) {
                 final char c = i == pathLen ? '\0' : pathChars[i];
                 if (c == '/' || c == '!' || c == '\0') {
                     final int segmentStartIdx = lastSepIdx + 1;


### PR DESCRIPTION
I've found that quite some time was spent on resolving/sanitizing paths, it did it 5 times for each .class, now this PR brings it to only once. `.jar` paths are still resolved multiple times but I didn't see an easy fix for it, and the impact seems to be minimal.

The changes in `FileUtils` only changes detecting when to sanitize, it should be equivalent to the previous code but much faster.

No clue why CI is failing, `mvn clean test` passes on my machine. Also the MacOS and Ubuntu CIs don't show the same errors lol