### PR TITLE
Lower-case URL scheme with Locale.ROOT to avoid Turkish-locale mismatch

### DIFF
--- a/src/main/java/nonapi/io/github/classgraph/scanspec/ScanSpec.java
+++ b/src/main/java/nonapi/io/github/classgraph/scanspec/ScanSpec.java
@@ -38,6 +38,7 @@ import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.List;
 import java.util.Set;
 
@@ -357,7 +358,7 @@ public class ScanSpec {
         if (allowedURLSchemes == null) {
             allowedURLSchemes = new HashSet<>();
         }
-        allowedURLSchemes.add(scheme.toLowerCase());
+        allowedURLSchemes.add(scheme.toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/src/test/java/nonapi/io/github/classgraph/scanspec/ScanSpecLocaleTest.java
+++ b/src/test/java/nonapi/io/github/classgraph/scanspec/ScanSpecLocaleTest.java
@@ -1,0 +1,26 @@
+package nonapi.io.github.classgraph.scanspec;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+/** Regression test: enableURLScheme must lower-case the scheme locale-independently. */
+public class ScanSpecLocaleTest {
+    @Test
+    public void enableURLSchemeIsLocaleIndependent() {
+        final Locale original = Locale.getDefault();
+        try {
+            // Turkish locale: "I".toLowerCase() -> dotless 'ı', so a naive
+            // toLowerCase() turns "FILE" into "fıle" and scheme matching breaks.
+            Locale.setDefault(new Locale("tr", "TR"));
+            final ScanSpec scanSpec = new ScanSpec();
+            scanSpec.enableURLScheme("FILE");
+            assertTrue(scanSpec.allowedURLSchemes.contains("file"),
+                    "scheme should be stored as ASCII 'file' regardless of default locale");
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}


### PR DESCRIPTION
`ScanSpec.enableURLScheme(scheme)` stores `scheme.toLowerCase()` using the JVM default locale. Scheme matching later compares against `URI.getScheme()`, which is ASCII lower-case (e.g. `file`). Under a Turkish locale, `"FILE".toLowerCase()` produces `"fıle"` (dotless i), so `enableURLScheme("FILE")` no longer matches the `file` scheme and those classpath entries are silently skipped. Any scheme containing `I`/`i` is affected (the classic Turkish-locale bug).

Fix: lower-case with `Locale.ROOT` so the stored scheme is always ASCII.

Adds `ScanSpecLocaleTest`, which sets the default locale to tr-TR, calls `enableURLScheme("FILE")`, and asserts the stored set contains `file`. The test fails on `latest` and passes with this change (verified locally with Maven).