### PR TITLE
fix: support mid-pattern ** multi-segment package globs (#940)

### DIFF
--- a/src/main/java/io/github/classgraph/ClassGraph.java
+++ b/src/main/java/io/github/classgraph/ClassGraph.java
@@ -682,12 +682,14 @@ public class ClassGraph {
      *
      * @param packageNames
      *            The fully-qualified names of packages to scan (using '.' as a separator). May include a glob
-     *            wildcard ({@code '*'}), which matches within a single package segment only. Any number of
-     *            wildcards may be used, e.g. {@code "com.*.internal.*"}. Sub-packages of a matched package are
-     *            also scanned, so a trailing {@code ".**"} is accepted but redundant; {@code "**"} may not appear
-     *            anywhere else. Note that a wildcard must match at least one package segment, so
-     *            {@code "java.awt.*"} matches the sub-packages of {@code java.awt} but not {@code java.awt}
-     *            itself -- to scan {@code java.awt} and everything below it, use {@code "java.awt"}.
+     *            wildcard ({@code '*'}), which matches within a single package segment only, or {@code "**"},
+     *            which matches zero or more package segments (so {@code "com.**.schema"} matches
+     *            {@code "com.api.base.schema"}). Any number of wildcards may be used, e.g.
+     *            {@code "com.*.internal.*"} or {@code "com.**.schema"}. Sub-packages of a matched package are also
+     *            scanned, so a trailing {@code ".**"} is accepted but redundant. Note that a single-segment
+     *            {@code '*'} wildcard must match at least one package segment, so {@code "java.awt.*"} matches the
+     *            sub-packages of {@code java.awt} but not {@code java.awt} itself -- to scan {@code java.awt} and
+     *            everything below it, use {@code "java.awt"}.
      * @return this (for method chaining).
      */
     public ClassGraph acceptPackages(final String... packageNames) {
@@ -721,12 +723,14 @@ public class ClassGraph {
      *
      * @param packageNames
      *            The fully-qualified names of packages to scan (using '.' as a separator). May include a glob
-     *            wildcard ({@code '*'}), which matches within a single package segment only. Any number of
-     *            wildcards may be used, e.g. {@code "com.*.internal.*"}. Sub-packages of a matched package are
-     *            also scanned, so a trailing {@code ".**"} is accepted but redundant; {@code "**"} may not appear
-     *            anywhere else. Note that a wildcard must match at least one package segment, so
-     *            {@code "java.awt.*"} matches the sub-packages of {@code java.awt} but not {@code java.awt}
-     *            itself -- to scan {@code java.awt} and everything below it, use {@code "java.awt"}.
+     *            wildcard ({@code '*'}), which matches within a single package segment only, or {@code "**"},
+     *            which matches zero or more package segments (so {@code "com.**.schema"} matches
+     *            {@code "com.api.base.schema"}). Any number of wildcards may be used, e.g.
+     *            {@code "com.*.internal.*"} or {@code "com.**.schema"}. Sub-packages of a matched package are also
+     *            scanned, so a trailing {@code ".**"} is accepted but redundant. Note that a single-segment
+     *            {@code '*'} wildcard must match at least one package segment, so {@code "java.awt.*"} matches the
+     *            sub-packages of {@code java.awt} but not {@code java.awt} itself -- to scan {@code java.awt} and
+     *            everything below it, use {@code "java.awt"}.
      * @return this (for method chaining).
      * @deprecated Use {@link #acceptPackages(String...)} instead.
      */
@@ -740,9 +744,10 @@ public class ClassGraph {
      *
      * @param paths
      *            The paths to scan, relative to the package root of the classpath element (with '/' as a
-     *            separator). May include a glob wildcard ({@code '*'}), which matches within a single path segment only. Any
-     *            number of wildcards may be used. Sub-directories of a matched path are also scanned, so a
-     *            trailing {@code "/**"} is accepted but redundant; {@code "**"} may not appear anywhere else.
+     *            separator). May include a glob wildcard ({@code '*'}), which matches within a single path segment
+     *            only, or {@code "**"}, which matches zero or more path segments. Any number of wildcards may be
+     *            used. Sub-directories of a matched path are also scanned, so a trailing {@code "/**"} is accepted
+     *            but redundant.
      * @return this (for method chaining).
      */
     public ClassGraph acceptPaths(final String... paths) {
@@ -774,9 +779,10 @@ public class ClassGraph {
      *
      * @param paths
      *            The paths to scan, relative to the package root of the classpath element (with '/' as a
-     *            separator). May include a glob wildcard ({@code '*'}), which matches within a single path segment only. Any
-     *            number of wildcards may be used. Sub-directories of a matched path are also scanned, so a
-     *            trailing {@code "/**"} is accepted but redundant; {@code "**"} may not appear anywhere else.
+     *            separator). May include a glob wildcard ({@code '*'}), which matches within a single path segment
+     *            only, or {@code "**"}, which matches zero or more path segments. Any number of wildcards may be
+     *            used. Sub-directories of a matched path are also scanned, so a trailing {@code "/**"} is accepted
+     *            but redundant.
      * @return this (for method chaining).
      * @deprecated Use {@link #acceptPaths(String...)} instead.
      */
@@ -886,12 +892,14 @@ public class ClassGraph {
      *
      * @param packageNames
      *            The fully-qualified names of packages to reject (using '.' as a separator). May include a glob
-     *            wildcard ({@code '*'}), which matches within a single package segment only. Any number of
-     *            wildcards may be used, e.g. {@code "com.*.internal.*"}. Sub-packages of a matched package are
-     *            also rejected, so a trailing {@code ".**"} is accepted but redundant; {@code "**"} may not appear
-     *            anywhere else. Note that a wildcard must match at least one package segment, so
-     *            {@code "java.awt.*"} matches the sub-packages of {@code java.awt} but not {@code java.awt}
-     *            itself -- to reject {@code java.awt} and everything below it, use {@code "java.awt"}.
+     *            wildcard ({@code '*'}), which matches within a single package segment only, or {@code "**"},
+     *            which matches zero or more package segments (so {@code "com.**.schema"} matches
+     *            {@code "com.api.base.schema"}). Any number of wildcards may be used, e.g.
+     *            {@code "com.*.internal.*"} or {@code "com.**.schema"}. Sub-packages of a matched package are also
+     *            rejected, so a trailing {@code ".**"} is accepted but redundant. Note that a single-segment
+     *            {@code '*'} wildcard must match at least one package segment, so {@code "java.awt.*"} matches the
+     *            sub-packages of {@code java.awt} but not {@code java.awt} itself -- to reject {@code java.awt}
+     *            and everything below it, use {@code "java.awt"}.
      * @return this (for method chaining).
      */
     public ClassGraph rejectPackages(final String... packageNames) {
@@ -919,12 +927,14 @@ public class ClassGraph {
      *
      * @param packageNames
      *            The fully-qualified names of packages to reject (using '.' as a separator). May include a glob
-     *            wildcard ({@code '*'}), which matches within a single package segment only. Any number of
-     *            wildcards may be used, e.g. {@code "com.*.internal.*"}. Sub-packages of a matched package are
-     *            also rejected, so a trailing {@code ".**"} is accepted but redundant; {@code "**"} may not appear
-     *            anywhere else. Note that a wildcard must match at least one package segment, so
-     *            {@code "java.awt.*"} matches the sub-packages of {@code java.awt} but not {@code java.awt}
-     *            itself -- to reject {@code java.awt} and everything below it, use {@code "java.awt"}.
+     *            wildcard ({@code '*'}), which matches within a single package segment only, or {@code "**"},
+     *            which matches zero or more package segments (so {@code "com.**.schema"} matches
+     *            {@code "com.api.base.schema"}). Any number of wildcards may be used, e.g.
+     *            {@code "com.*.internal.*"} or {@code "com.**.schema"}. Sub-packages of a matched package are also
+     *            rejected, so a trailing {@code ".**"} is accepted but redundant. Note that a single-segment
+     *            {@code '*'} wildcard must match at least one package segment, so {@code "java.awt.*"} matches the
+     *            sub-packages of {@code java.awt} but not {@code java.awt} itself -- to reject {@code java.awt}
+     *            and everything below it, use {@code "java.awt"}.
      * @return this (for method chaining).
      * @deprecated Use {@link #rejectPackages(String...)} instead.
      */
@@ -937,9 +947,10 @@ public class ClassGraph {
      * Prevent the scanning of one or more specific paths and their sub-directories / nested paths.
      *
      * @param paths
-     *            The paths to reject (with '/' as a separator). May include a glob wildcard ({@code '*'}), which matches within a single path segment only. Any
-     *            number of wildcards may be used. Sub-directories of a matched path are also rejected, so a
-     *            trailing {@code "/**"} is accepted but redundant; {@code "**"} may not appear anywhere else.
+     *            The paths to reject (with '/' as a separator). May include a glob wildcard ({@code '*'}), which
+     *            matches within a single path segment only, or {@code "**"}, which matches zero or more path
+     *            segments. Any number of wildcards may be used. Sub-directories of a matched path are also
+     *            rejected, so a trailing {@code "/**"} is accepted but redundant.
      * @return this (for method chaining).
      */
     public ClassGraph rejectPaths(final String... paths) {
@@ -965,9 +976,10 @@ public class ClassGraph {
      * Use {@link #rejectPaths(String...)} instead.
      *
      * @param paths
-     *            The paths to reject (with '/' as a separator). May include a glob wildcard ({@code '*'}), which matches within a single path segment only. Any
-     *            number of wildcards may be used. Sub-directories of a matched path are also rejected, so a
-     *            trailing {@code "/**"} is accepted but redundant; {@code "**"} may not appear anywhere else.
+     *            The paths to reject (with '/' as a separator). May include a glob wildcard ({@code '*'}), which
+     *            matches within a single path segment only, or {@code "**"}, which matches zero or more path
+     *            segments. Any number of wildcards may be used. Sub-directories of a matched path are also
+     *            rejected, so a trailing {@code "/**"} is accepted but redundant.
      * @return this (for method chaining).
      * @deprecated Use {@link #rejectPaths(String...)} instead.
      */

--- a/src/main/java/nonapi/io/github/classgraph/scanspec/AcceptReject.java
+++ b/src/main/java/nonapi/io/github/classgraph/scanspec/AcceptReject.java
@@ -104,15 +104,16 @@ public abstract class AcceptReject {
 
     /**
      * Convert a glob to a regexp {@link Pattern}, where {@code '*'} matches zero or more characters within a
-     * single package or path segment, i.e. does not span {@link #separatorChar}. Any number of wildcards may be
-     * used in a single glob.
+     * single package or path segment, i.e. does not span {@link #separatorChar}, and {@code "**"} matches zero or
+     * more characters spanning any number of segments (including separators). Any number of wildcards may be used
+     * in a single glob. (#643, #870, #940)
      *
      * <p>
-     * {@code "**"} is not accepted here: as the final segment of an accept or reject criterion it means "and
-     * everything below", which is already the default for
-     * {@link io.github.classgraph.ClassGraph#acceptPackages(String...)} and friends, so it is stripped by the
-     * caller before the glob reaches this method. In any other position it is
-     * rejected, since a separator-spanning wildcard would defeat the segment-bounded matching. (#643, #870)
+     * As the final segment of an accept or reject criterion, {@code "**"} means "and everything below", which is
+     * already the default for {@link io.github.classgraph.ClassGraph#acceptPackages(String...)} and friends, so it
+     * is stripped by the caller before the glob reaches this method. In any other position, {@code "**"} is a
+     * multi-segment wildcard -- for example {@code "org.example.**.schema"} matches
+     * {@code "org.example.api.base.schema"} and {@code "org.example.other.schema"}.
      *
      * @param glob
      *            the glob
@@ -122,20 +123,38 @@ public abstract class AcceptReject {
      *            if true, the pattern matches any string <i>starting with</i> a string matching the glob, rather
      *            than requiring a whole-string match
      * @return the pattern
-     * @throws IllegalArgumentException
-     *             if the glob contains {@code "**"}
      */
     public static Pattern segmentGlobToPattern(final String glob, final char separatorChar,
             final boolean prefixMatch) {
+        final boolean separatorNeedsEscape = "\\^$.|?*+()[]{}".indexOf(separatorChar) >= 0;
+        final String separatorRegex = separatorNeedsEscape ? "\\" + separatorChar
+                : Character.toString(separatorChar);
         final StringBuilder buf = new StringBuilder("^");
         for (int i = 0; i < glob.length(); i++) {
             final char c = glob.charAt(i);
             if (c == '*') {
                 if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
-                    throw new IllegalArgumentException("\"**\" may only be used as the final segment of a glob: "
-                            + glob);
+                    // "**" matches zero or more segments (including separators). When bounded by separators on
+                    // both sides (e.g. "a.**.b" / "a/**/b"), allow zero intermediate segments so that "a.b" /
+                    // "a/b" also matches, like a conventional path glob. (#940)
+                    final boolean precededBySeparator = separatorNeedsEscape
+                            ? buf.length() >= 2 && buf.charAt(buf.length() - 2) == '\\'
+                                    && buf.charAt(buf.length() - 1) == separatorChar
+                            : buf.length() >= 1 && buf.charAt(buf.length() - 1) == separatorChar;
+                    final boolean followedBySeparator = i + 2 < glob.length()
+                            && glob.charAt(i + 2) == separatorChar;
+                    if (precededBySeparator && followedBySeparator) {
+                        // Drop the separator already emitted before "**"; re-emit it as optional with the span.
+                        buf.setLength(buf.length() - (separatorNeedsEscape ? 2 : 1));
+                        buf.append("(?:").append(separatorRegex).append(".*)?");
+                    } else {
+                        buf.append(".*");
+                    }
+                    i++; // skip second '*'
+                } else {
+                    // '*' matches within a single segment only
+                    buf.append("[^").append(separatorChar).append("]*");
                 }
-                buf.append("[^").append(separatorChar).append("]*");
             } else if ("\\^$.|?*+()[]{}".indexOf(c) >= 0) {
                 buf.append('\\').append(c);
             } else {
@@ -151,7 +170,7 @@ public abstract class AcceptReject {
     /**
      * Strip a trailing {@code "**"} segment from a normalized package name or path, if present. A trailing
      * {@code "**"} means "and everything below", which is what the recursive accept/reject methods already do, so
-     * it can simply be removed. {@code "**"} in any other position is rejected by
+     * it can simply be removed. {@code "**"} in any other position is a multi-segment wildcard handled by
      * {@link #segmentGlobToPattern(String, char, boolean)}.
      *
      * @param packageOrPath

--- a/src/test/java/io/github/classgraph/issues/issue870/Issue870Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue870/Issue870Test.java
@@ -1,7 +1,6 @@
 package io.github.classgraph.issues.issue870;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -106,13 +105,16 @@ public class Issue870Test {
         assertThat(scan(PKG + ".**")).contains(ALPHA_THING, BETA_THING, SUB_THING, OTHER_THING);
     }
 
-    /** {@code "**"} anywhere but the final segment is rejected, since it would defeat segment-bounded matching. */
+    /**
+     * Mid-pattern {@code "**"} is a multi-segment wildcard (#940), so it can span intermediate packages that a
+     * single {@code '*'} cannot.
+     */
     @Test
-    public void nonTrailingDoubleGlobIsRejected() {
-        assertThatThrownBy(() -> scan(PKG + ".**.domain")).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("**");
-        assertThatThrownBy(() -> scan(PKG + ".al**ha.domain")).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("**");
+    public void midPackageDoubleGlobSpansSegments() {
+        assertThat(scan(PKG + ".**.domain")).contains(ALPHA_THING, BETA_THING, SUB_THING);
+        assertThat(scan(PKG + ".**.domain")).doesNotContain(OTHER_THING);
+        // "**" embedded in a segment name spans characters (including separators) like a conventional glob
+        assertThat(scan(PKG + ".al**ha.domain")).contains(ALPHA_THING, SUB_THING);
     }
 
     /** Reject criteria support globs too, and are likewise recursive. */

--- a/src/test/java/io/github/classgraph/issues/issue940/Issue940Test.java
+++ b/src/test/java/io/github/classgraph/issues/issue940/Issue940Test.java
@@ -1,0 +1,99 @@
+package io.github.classgraph.issues.issue940;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
+import nonapi.io.github.classgraph.scanspec.AcceptReject;
+
+/**
+ * Issue 940: after 4.8.186, a single {@code '*'} no longer spans package separators, and there was no way to match
+ * an unknown number of intermediate packages mid-pattern. {@code "**"} is now a multi-segment wildcard in any
+ * position (not only trailing).
+ */
+public class Issue940Test {
+    private static final String PKG = Issue940Test.class.getPackage().getName();
+
+    private static final String SCHEMA_CLASS = PKG + ".api.base.schema.SchemaClass";
+    private static final String OTHER_SCHEMA_CLASS = PKG + ".other.schema.OtherSchemaClass";
+    private static final String MODULE_CLASS = PKG + ".api.base.test.module.ModuleClass";
+    private static final String OTHER_CLASS = PKG + ".api.base.other.OtherClass";
+
+    private static List<String> scan(final String... acceptedPackages) {
+        try (ScanResult scanResult = new ClassGraph().enableClassInfo().acceptPackages(acceptedPackages).scan()) {
+            return scanResult.getAllClasses().getNames();
+        }
+    }
+
+    /**
+     * The motivating example from the issue: {@code org.creekservice.**.schema} style patterns must match packages
+     * with an unknown number of intermediate segments.
+     */
+    @Test
+    public void midPackageDoubleGlobMatchesUnknownIntermediatePackages() {
+        assertThat(scan(PKG + ".**.schema")).contains(SCHEMA_CLASS, OTHER_SCHEMA_CLASS);
+        assertThat(scan(PKG + ".**.schema")).doesNotContain(MODULE_CLASS, OTHER_CLASS);
+    }
+
+    /** A single {@code '*'} still matches only one segment (the 4.8.186 behaviour). */
+    @Test
+    public void singleStarStillDoesNotSpanSegments() {
+        assertThat(scan(PKG + ".*.schema")).contains(OTHER_SCHEMA_CLASS);
+        assertThat(scan(PKG + ".*.schema")).doesNotContain(SCHEMA_CLASS);
+    }
+
+    /**
+     * Leading multi-segment wildcard: {@code **.api.base.test.module} recovers the pre-4.8.186 ability of
+     * {@code *.api.*}-style patterns to match when {@code api} is not the first package segment.
+     */
+    @Test
+    public void leadingDoubleGlobMatchesBeforeKnownSegment() {
+        assertThat(scan("**.api.base.test.module")).contains(MODULE_CLASS);
+        assertThat(scan(PKG + ".api.**")).contains(SCHEMA_CLASS, MODULE_CLASS, OTHER_CLASS);
+    }
+
+    /** Mid-pattern {@code "**"} is recursive into sub-packages of a matched package, like a literal accept. */
+    @Test
+    public void midPackageDoubleGlobIsRecursive() {
+        // Matching the package "….api.base" via ** should also include its sub-packages when accepted recursively
+        assertThat(scan(PKG + ".**.base")).contains(SCHEMA_CLASS, MODULE_CLASS, OTHER_CLASS);
+        assertThat(scan(PKG + ".**.base")).doesNotContain(OTHER_SCHEMA_CLASS);
+    }
+
+    /** Reject criteria support mid-pattern {@code "**"} too. */
+    @Test
+    public void midPackageDoubleGlobReject() {
+        try (ScanResult scanResult = new ClassGraph().enableClassInfo().acceptPackages(PKG)
+                .rejectPackages(PKG + ".**.schema").scan()) {
+            assertThat(scanResult.getAllClasses().getNames()).contains(MODULE_CLASS, OTHER_CLASS)
+                    .doesNotContain(SCHEMA_CLASS, OTHER_SCHEMA_CLASS);
+        }
+    }
+
+    /** Direct unit coverage of the glob-to-pattern conversion used by package accept/reject. */
+    @Test
+    public void segmentGlobToPatternSupportsMidDoubleGlob() {
+        final Pattern packagePattern = AcceptReject.segmentGlobToPattern("org.creekservice.**.schema", '.',
+                /* prefixMatch = */ false);
+        assertThat(packagePattern.matcher("org.creekservice.api.base.schema").matches()).isTrue();
+        assertThat(packagePattern.matcher("org.creekservice.other.schema").matches()).isTrue();
+        assertThat(packagePattern.matcher("org.creekservice.schema").matches()).isTrue();
+        assertThat(packagePattern.matcher("org.creekservice.api.base.other").matches()).isFalse();
+
+        final Pattern pathPattern = AcceptReject.segmentGlobToPattern("org/creekservice/**/schema/", '/',
+                /* prefixMatch = */ false);
+        assertThat(pathPattern.matcher("org/creekservice/api/base/schema/").matches()).isTrue();
+        assertThat(pathPattern.matcher("org/creekservice/other/schema/").matches()).isTrue();
+        assertThat(pathPattern.matcher("org/creekservice/schema/").matches()).isTrue();
+
+        // Single '*' remains segment-bounded
+        final Pattern singleStar = AcceptReject.segmentGlobToPattern("org.creekservice.*.schema", '.', false);
+        assertThat(singleStar.matcher("org.creekservice.other.schema").matches()).isTrue();
+        assertThat(singleStar.matcher("org.creekservice.api.base.schema").matches()).isFalse();
+    }
+}

--- a/src/test/java/io/github/classgraph/issues/issue940/api/base/other/OtherClass.java
+++ b/src/test/java/io/github/classgraph/issues/issue940/api/base/other/OtherClass.java
@@ -1,0 +1,5 @@
+package io.github.classgraph.issues.issue940.api.base.other;
+
+/** Fixture: same intermediate path as a schema package, but not ending in {@code schema}. */
+public class OtherClass {
+}

--- a/src/test/java/io/github/classgraph/issues/issue940/api/base/schema/SchemaClass.java
+++ b/src/test/java/io/github/classgraph/issues/issue940/api/base/schema/SchemaClass.java
@@ -1,0 +1,5 @@
+package io.github.classgraph.issues.issue940.api.base.schema;
+
+/** Fixture: multi-segment intermediate packages before {@code schema}. */
+public class SchemaClass {
+}

--- a/src/test/java/io/github/classgraph/issues/issue940/api/base/test/module/ModuleClass.java
+++ b/src/test/java/io/github/classgraph/issues/issue940/api/base/test/module/ModuleClass.java
@@ -1,0 +1,5 @@
+package io.github.classgraph.issues.issue940.api.base.test.module;
+
+/** Fixture: package containing {@code api} as a non-leading segment. */
+public class ModuleClass {
+}

--- a/src/test/java/io/github/classgraph/issues/issue940/other/schema/OtherSchemaClass.java
+++ b/src/test/java/io/github/classgraph/issues/issue940/other/schema/OtherSchemaClass.java
@@ -1,0 +1,5 @@
+package io.github.classgraph.issues.issue940.other.schema;
+
+/** Fixture: single intermediate package before {@code schema}. */
+public class OtherSchemaClass {
+}


### PR DESCRIPTION
## Summary

After 4.8.186, a single `*` in package/path accept/reject globs matches only within one segment. That fixed over-matching, but left no way to match an *unknown number of intermediate packages* mid-pattern (e.g. `org.creekservice.*.schema` no longer matches `org.creekservice.api.base.schema`).

This change teaches segment globs to treat `**` as a multi-segment wildcard in any position:

| Pattern | Target package | Result |
|---------|----------------|--------|
| `org.example.**.schema` | `org.example.api.base.schema` | match |
| `org.example.**.schema` | `org.example.other.schema` | match |
| `org.example.*.schema` | `org.example.api.base.schema` | no match (single `*` still one segment) |
| `org.example.**.schema` | `org.example.schema` | match (zero intermediate segments) |

Trailing `.**` / `/**` is unchanged: it still means “and everything below” and is stripped as redundant for the recursive accept/reject APIs.

## Changes

- `AcceptReject.segmentGlobToPattern`: `**` → multi-segment span; `*` stays segment-bounded
- Javadoc on `acceptPackages` / `rejectPackages` / `acceptPaths` / `rejectPaths` (and deprecated aliases)
- Regression tests for #940 (including the creek-style mid-package examples)
- Update #870 test that previously asserted mid-pattern `**` was rejected

## Test plan

- [x] `./mvnw -Dtest=Issue940Test,Issue870Test,Issue884Test test`
- [x] Broader issue/package tests (`Issue*Test`, `DefaultPackageTest`, `DisableRecursiveScanningTest`)

Fixes #940